### PR TITLE
Fixing squid:S2325 -private methods that don't access instance data should be static

### DIFF
--- a/src/main/java/net/openhft/hashing/CityAndFarmHash_1_1.java
+++ b/src/main/java/net/openhft/hashing/CityAndFarmHash_1_1.java
@@ -270,7 +270,7 @@ class CityAndFarmHash_1_1 {
         public static final AsLongHashFunction INSTANCE = new AsLongHashFunction();
         private static final long serialVersionUID = 0L;
 
-        private Object readResolve() {
+        private static Object readResolve() {
             return INSTANCE;
         }
 
@@ -628,7 +628,7 @@ class CityAndFarmHash_1_1 {
         public static final Na INSTANCE = new Na();
         private static final long serialVersionUID = 0L;
 
-        private Object readResolve() {
+        private static Object readResolve() {
             return INSTANCE;
         }
 
@@ -683,7 +683,7 @@ class CityAndFarmHash_1_1 {
         public static final Uo INSTANCE = new Uo();
         private static final long serialVersionUID = 0L;
 
-        private Object readResolve() {
+        private static Object readResolve() {
             return INSTANCE;
         }
 

--- a/src/main/java/net/openhft/hashing/MurmurHash_3.java
+++ b/src/main/java/net/openhft/hashing/MurmurHash_3.java
@@ -266,7 +266,7 @@ class MurmurHash_3 {
         public static final AsLongHashFunction INSTANCE = new AsLongHashFunction();
         private static final long serialVersionUID = 0L;
 
-        private Object readResolve() {
+        private static Object readResolve() {
             return INSTANCE;
         }
 

--- a/src/main/java/net/openhft/hashing/XxHash_r39.java
+++ b/src/main/java/net/openhft/hashing/XxHash_r39.java
@@ -207,7 +207,7 @@ class XxHash_r39 {
         public static final AsLongHashFunction SEEDLESS_INSTANCE = new AsLongHashFunction();
         private static final long serialVersionUID = 0L;
 
-        private Object readResolve() {
+        private static Object readResolve() {
             return SEEDLESS_INSTANCE;
         }
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule " squid:S2325 - "private" methods that don't access instance data should be "static"". You can find more information about the issues here:
https://dev.eclipse.org/sonar/rules/show/squid:S2325

Please let me know if you have any questions.
Sameer Misger