### PR TITLE
Downgrade maven-bundle-plugin to 3.5.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -160,6 +160,7 @@
              <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
+                 <version>3.5.1</version>
                 <extensions>true</extensions>
                 <configuration>
                     <instructions>


### PR DESCRIPTION
The higher version of  ·`maven-bundle-plugin` will need Java 8. Otherwise, it will cause [Travis CI build failure](https://travis-ci.org/OpenHFT/Zero-Allocation-Hashing/jobs/497562484).