### PR TITLE
Add new api for more than 64-bit hash

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>18.0</version>
+            <version>28.2-android</version>
             <scope>test</scope>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,13 @@
             <scope>provided</scope>
         </dependency>
 
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+            <version>3.0.2</version>
+            <scope>provided</scope>
+        </dependency>
+
         <!-- test dependencies -->
 
         <dependency>
@@ -56,7 +63,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>28.2-android</version>
+            <version>18.0</version>
             <scope>test</scope>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.0.0-M4</version>
                 <configuration>
                     <systemPropertyVariables>
                         <project.build.directory>${project.build.directory}</project.build.directory>

--- a/pom.xml
+++ b/pom.xml
@@ -67,11 +67,10 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.0</version>
+                <version>3.8.1</version>
                 <configuration>
                     <source>1.7</source>
                     <target>1.7</target>
-                    <verbose>true</verbose>
                     <encoding>UTF-8</encoding>
                 </configuration>
             </plugin>

--- a/src/main/java/net/openhft/hashing/Access.java
+++ b/src/main/java/net/openhft/hashing/Access.java
@@ -79,6 +79,7 @@ public abstract class Access<T> {
      * @param <T> the type of objects to access
      * @return the unsafe memory {@code Access}
      */
+    @SuppressWarnings("unchecked")
     public static <T> Access<T> unsafe() {
         return (Access<T>) UnsafeAccess.INSTANCE;
     }
@@ -112,6 +113,7 @@ public abstract class Access<T> {
      * @return the {@code Access} to {@link CharSequence}s backed by native {@code char} reads
      * @see #toCharSequence(ByteOrder)
      */
+    @SuppressWarnings("unchecked")
     public static <T extends CharSequence> Access<T> toNativeCharSequence() {
         return (Access<T>) CharSequenceAccess.nativeCharSequenceAccess();
     }
@@ -134,6 +136,7 @@ public abstract class Access<T> {
      * @param <T> the {@code CharSequence} subtype to access
      * @see #toNativeCharSequence()
      */
+    @SuppressWarnings("unchecked")
     public static <T extends CharSequence> Access<T> toCharSequence(ByteOrder backingOrder) {
         return (Access<T>) CharSequenceAccess.charSequenceAccess(backingOrder);
     }

--- a/src/main/java/net/openhft/hashing/CityAndFarmHash_1_1.java
+++ b/src/main/java/net/openhft/hashing/CityAndFarmHash_1_1.java
@@ -19,7 +19,7 @@ package net.openhft.hashing;
 import static java.lang.Long.reverseBytes;
 import static java.lang.Long.rotateRight;
 import static java.nio.ByteOrder.LITTLE_ENDIAN;
-import static net.openhft.hashing.LongHashFunction.NATIVE_LITTLE_ENDIAN;
+import static net.openhft.hashing.Util.NATIVE_LITTLE_ENDIAN;
 
 /**
  * Adapted from the C++ CityHash implementation from Google at

--- a/src/main/java/net/openhft/hashing/DualHashFunction.java
+++ b/src/main/java/net/openhft/hashing/DualHashFunction.java
@@ -65,9 +65,9 @@ abstract class DualHashFunction extends LongTupleHashFunction {
     }
     @Override
     public <T> long[] hash(@Nullable final T input, final Access<T> access, final long off, final long len) {
-	final long[] result = newResultArray();
+        final long[] result = newResultArray();
         dualHash(input, access, off, len, result);
-	return result;
+        return result;
     }
 
     // LongTupleHashFunction and LongHashFunction are stateless objects after construction

--- a/src/main/java/net/openhft/hashing/DualHashFunction.java
+++ b/src/main/java/net/openhft/hashing/DualHashFunction.java
@@ -11,8 +11,13 @@ abstract class DualHashFunction extends LongTupleHashFunction {
     private static final long serialVersionUID = 0L;
 
     private transient final int resultLength = newResultArray().length;
-    private long checkResult(final long[] result) {
-        return result[resultLength - 1];
+    private void checkResult(final long[] result) {
+        if (null == result) {
+            throw new NullPointerException();
+        }
+        if (result.length < resultLength) {
+            throw new IllegalArgumentException("The input result array has not enough space!");
+        }
     }
 
     protected abstract long dualHashLong(long input, @Nullable long[] result);

--- a/src/main/java/net/openhft/hashing/DualHashFunction.java
+++ b/src/main/java/net/openhft/hashing/DualHashFunction.java
@@ -10,94 +10,108 @@ import javax.annotation.ParametersAreNonnullByDefault;
 abstract class DualHashFunction extends LongTupleHashFunction {
     private static final long serialVersionUID = 0L;
 
+    private transient final int resultLength = newResultArray().length;
+    private long checkResult(final long[] result) {
+        return result[resultLength - 1];
+    }
+
     protected abstract long dualHashLong(long input, @Nullable long[] result);
     @Override
     public void hashLong(final long input, final long[] result) {
+        checkResult(result);
         dualHashLong(input, result);
     }
 
     protected abstract long dualHashInt(int input, @Nullable long[] result);
     @Override
     public void hashInt(final int input, final long[] result) {
+        checkResult(result);
         dualHashInt(input, result);
     }
 
     protected abstract long dualHashShort(short input, @Nullable long[] result);
     @Override
     public void hashShort(final short input, final long[] result) {
+        checkResult(result);
         dualHashShort(input, result);
     }
 
     protected abstract long dualHashChar(char input, @Nullable long[] result);
     @Override
     public void hashChar(final char input, final long[] result) {
+        checkResult(result);
         dualHashChar(input, result);
     }
 
     protected abstract long dualHashByte(byte input, @Nullable long[] result);
     @Override
     public void hashByte(final byte input, final long[] result) {
+        checkResult(result);
         dualHashByte(input, result);
     }
 
     protected abstract long dualHashVoid(@Nullable long[] result);
     @Override
     public void hashVoid(final long[] result) {
+        checkResult(result);
         dualHashVoid(result);
     }
 
     protected abstract <T> long dualHash(@Nullable T input, Access<T> access, long off, long len, @Nullable long[] result);
     @Override
     public <T> void hash(@Nullable final T input, final Access<T> access, final long off, final long len, final long[] result) {
+        checkResult(result);
         dualHash(input, access, off, len, result);
     }
+    @Override
+    public <T> long[] hash(@Nullable final T input, final Access<T> access, final long off, final long len) {
+	final long[] result = newResultArray();
+        dualHash(input, access, off, len, result);
+	return result;
+    }
 
-    @Nullable
-    private transient volatile LongHashFunction longHashFunction = null;
+    // LongTupleHashFunction and LongHashFunction are stateless objects after construction
+    // so cache the LongHashFunction instance.
+    @NotNull
+    private transient final LongHashFunction longHashFunction = new LongHashFunction() {
+        @Override
+        public long hashLong(final long input) {
+            return dualHashLong(input, null);
+        }
+
+        @Override
+        public long hashInt(final int input) {
+            return dualHashInt(input, null);
+        }
+
+        @Override
+        public long hashShort(final short input) {
+            return dualHashShort(input, null);
+        }
+
+        @Override
+        public long hashChar(final char input) {
+            return dualHashChar(input, null);
+        }
+
+        @Override
+        public long hashByte(final byte input) {
+            return dualHashByte(input, null);
+        }
+
+        @Override
+        public long hashVoid() {
+            return dualHashVoid(null);
+        }
+
+        @Override
+        public <T> long hash(@Nullable final T input, final Access<T> access, final long off, final long len) {
+            return dualHash(input, access, off, len, null);
+        }
+    };
 
     @NotNull
     protected LongHashFunction asLongHashFunction() {
-        if (null == longHashFunction) {
-            // LongTupleHashFunction and LongHashFunction are stateless objects after construction
-            // so when caching the instance, we don't care the concurrence,
-            // and this function is still thread safe.
-            longHashFunction = new LongHashFunction() {
-                @Override
-                public long hashLong(final long input) {
-                    return dualHashLong(input, null);
-                }
-
-                @Override
-                public long hashInt(final int input) {
-                    return dualHashInt(input, null);
-                }
-
-                @Override
-                public long hashShort(final short input) {
-                    return dualHashShort(input, null);
-                }
-
-                @Override
-                public long hashChar(final char input) {
-                    return dualHashChar(input, null);
-                }
-
-                @Override
-                public long hashByte(final byte input) {
-                    return dualHashByte(input, null);
-                }
-
-                @Override
-                public long hashVoid() {
-                    return dualHashVoid(null);
-                }
-
-                @Override
-                public <T> long hash(@Nullable final T input, final Access<T> access, final long off, final long len) {
-                    return dualHash(input, access, off, len, null);
-                }
-            };
-        }
         return longHashFunction;
     }
 }

--- a/src/main/java/net/openhft/hashing/DualHashFunction.java
+++ b/src/main/java/net/openhft/hashing/DualHashFunction.java
@@ -1,0 +1,92 @@
+package net.openhft.hashing;
+
+import org.jetbrains.annotations.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
+
+// An internal helper class for casting LongTupleHashFunction as LongHashFunction
+
+@ParametersAreNonnullByDefault
+abstract class DualHashFunction extends LongTupleHashFunction {
+    private static final long serialVersionUID = 0L;
+
+    protected abstract long dualHashLong(long input, @Nullable long[] result);
+    @Override
+    public void hashLong(final long input, final long[] result) {
+        dualHashLong(input, result);
+    }
+
+    protected abstract long dualHashInt(int input, @Nullable long[] result);
+    @Override
+    public void hashInt(final int input, final long[] result) {
+        dualHashInt(input, result);
+    }
+
+    protected abstract long dualHashShort(short input, @Nullable long[] result);
+    @Override
+    public void hashShort(final short input, final long[] result) {
+        dualHashShort(input, result);
+    }
+
+    protected abstract long dualHashChar(char input, @Nullable long[] result);
+    @Override
+    public void hashChar(final char input, final long[] result) {
+        dualHashChar(input, result);
+    }
+
+    protected abstract long dualHashByte(byte input, @Nullable long[] result);
+    @Override
+    public void hashByte(final byte input, final long[] result) {
+        dualHashByte(input, result);
+    }
+
+    protected abstract long dualHashVoid(@Nullable long[] result);
+    @Override
+    public void hashVoid(final long[] result) {
+        dualHashVoid(result);
+    }
+
+    protected abstract <T> long dualHash(@Nullable T input, Access<T> access, long off, long len, @Nullable long[] result);
+    @Override
+    public <T> void hash(@Nullable final T input, final Access<T> access, final long off, final long len, final long[] result) {
+        dualHash(input, access, off, len, result);
+    }
+
+    protected LongHashFunction asLongHashFunction() {
+        return new LongHashFunction() {
+            @Override
+            public long hashLong(final long input) {
+                return dualHashLong(input, null);
+            }
+        
+            @Override
+            public long hashInt(final int input) {
+                return dualHashInt(input, null);
+            }
+        
+            @Override
+            public long hashShort(final short input) {
+                return dualHashShort(input, null);
+            }
+        
+            @Override
+            public long hashChar(final char input) {
+                return dualHashChar(input, null);
+            }
+        
+            @Override
+            public long hashByte(final byte input) {
+                return dualHashByte(input, null);
+            }
+        
+            @Override
+            public long hashVoid() {
+                return dualHashVoid(null);
+            }
+        
+            @Override
+            public <T> long hash(@Nullable final T input, final Access<T> access, final long off, final long len) {
+                return dualHash(input, access, off, len, null);
+            }
+        };
+    }
+}

--- a/src/main/java/net/openhft/hashing/HotSpotPrior7u6StringHash.java
+++ b/src/main/java/net/openhft/hashing/HotSpotPrior7u6StringHash.java
@@ -42,4 +42,11 @@ enum HotSpotPrior7u6StringHash implements StringHash {
         int offset = UnsafeAccess.UNSAFE.getInt(s, offsetOffset);
         return hashFunction.hashChars(value, offset + off, len);
     }
+
+    @Override
+    public long longHash(String s, LongTupleHashFunction hashFunction, int off, int len, long[] result) {
+        char[] value = (char[]) UnsafeAccess.UNSAFE.getObject(s, valueOffset);
+        int offset = UnsafeAccess.UNSAFE.getInt(s, offsetOffset);
+        return hashFunction.hashChars(value, offset + off, len, result);
+    }
 }

--- a/src/main/java/net/openhft/hashing/HotSpotPrior7u6StringHash.java
+++ b/src/main/java/net/openhft/hashing/HotSpotPrior7u6StringHash.java
@@ -17,7 +17,9 @@
 package net.openhft.hashing;
 
 import java.lang.reflect.Field;
+import javax.annotation.ParametersAreNonnullByDefault;
 
+@ParametersAreNonnullByDefault
 enum HotSpotPrior7u6StringHash implements StringHash {
     INSTANCE;
 
@@ -44,9 +46,10 @@ enum HotSpotPrior7u6StringHash implements StringHash {
     }
 
     @Override
-    public long longHash(String s, LongTupleHashFunction hashFunction, int off, int len, long[] result) {
-        char[] value = (char[]) UnsafeAccess.UNSAFE.getObject(s, valueOffset);
-        int offset = UnsafeAccess.UNSAFE.getInt(s, offsetOffset);
-        return hashFunction.hashChars(value, offset + off, len, result);
+    public void hash(final String s, final LongTupleHashFunction hashFunction,
+                    final int off, final int len, final long[] result) {
+        final char[] value = (char[]) UnsafeAccess.UNSAFE.getObject(s, valueOffset);
+        final int offset = UnsafeAccess.UNSAFE.getInt(s, offsetOffset);
+        hashFunction.hashChars(value, offset + off, len, result);
     }
 }

--- a/src/main/java/net/openhft/hashing/LongHashFunction.java
+++ b/src/main/java/net/openhft/hashing/LongHashFunction.java
@@ -23,10 +23,10 @@ import java.io.Serializable;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 
-import static java.nio.ByteOrder.LITTLE_ENDIAN;
 import static java.nio.ByteOrder.nativeOrder;
 import static net.openhft.hashing.CharSequenceAccess.nativeCharSequenceAccess;
 import static net.openhft.hashing.UnsafeAccess.*;
+import static net.openhft.hashing.Util.*;
 
 /**
  * Hash function producing {@code long}-valued result from byte sequences of any length and
@@ -68,34 +68,6 @@ import static net.openhft.hashing.UnsafeAccess.*;
  */
 public abstract class LongHashFunction implements Serializable {
     private static final long serialVersionUID = 0L;
-
-    static final boolean NATIVE_LITTLE_ENDIAN = nativeOrder() == LITTLE_ENDIAN;
-    static final byte TRUE_BYTE_VALUE;
-    static final byte FALSE_BYTE_VALUE;
-
-    static {
-        byte trueByteValue, falseByteValue;
-        try {
-            trueByteValue = trueByteValue();
-            falseByteValue = falseByteValue();
-        } catch (Throwable t) {
-            // Unsafe in pre-Nougat Android does not have getByte(), fall back to some reasonable
-            // value
-            trueByteValue = 1;
-            falseByteValue = 0;
-        }
-
-        TRUE_BYTE_VALUE = trueByteValue;
-        FALSE_BYTE_VALUE = falseByteValue;
-    }
-
-    private static byte trueByteValue() {
-        return UNSAFE.getByte(new boolean[] {true}, BOOLEAN_BASE);
-    }
-
-    private static byte falseByteValue() {
-        return UNSAFE.getByte(new boolean[] {false}, BOOLEAN_BASE);
-    }
 
     /**
      * Returns a hash function implementing
@@ -248,7 +220,7 @@ public abstract class LongHashFunction implements Serializable {
      * @see #murmur_3(long)
      */
     public static LongHashFunction murmur_3() {
-        return MurmurHash_3.asLongTupleHashFunctionWithoutSeed();
+        return MurmurHash_3.asLongHashFunctionWithoutSeed();
     }
 
     /**
@@ -261,7 +233,7 @@ public abstract class LongHashFunction implements Serializable {
      * @see #murmur_3()
      */
     public static LongHashFunction murmur_3(long seed) {
-        return MurmurHash_3.asLongTupleHashFunctionWithSeed(seed);
+        return MurmurHash_3.asLongHashFunctionWithSeed(seed);
     }
 
     /**
@@ -338,37 +310,6 @@ public abstract class LongHashFunction implements Serializable {
      */
     public static LongHashFunction metro(long seed) {
         return MetroHash.asLongHashFunctionWithSeed(seed);
-    }
-
-    static StringHash stringHash;
-    static  {
-        try {
-            if (System.getProperty("java.vm.name").contains("HotSpot")) {
-                String javaVersion = System.getProperty("java.version");
-                if (javaVersion.compareTo("1.7.0_06") >= 0) {
-                    if (javaVersion.compareTo("1.9") >= 0) {
-                        stringHash = UnknownJvmStringHash.INSTANCE;
-                    } else {
-                        stringHash = ModernHotSpotStringHash.INSTANCE;
-                    }
-                } else {
-                    stringHash = HotSpotPrior7u6StringHash.INSTANCE;
-                }
-            } else {
-                // try to initialize this version anyway
-                stringHash = HotSpotPrior7u6StringHash.INSTANCE;
-            }
-        } catch (Throwable e) {
-            // ignore
-        } finally {
-            if (stringHash == null)
-                stringHash = UnknownJvmStringHash.INSTANCE;
-        }
-    }
-
-    static void checkArrayOffs(int arrayLength, int off, int len) {
-        if (len < 0 || off < 0 || off + len > arrayLength || off + len < 0)
-            throw new IndexOutOfBoundsException();
     }
 
     /**
@@ -596,7 +537,7 @@ public abstract class LongHashFunction implements Serializable {
      * Shortcut for {@link #hashChars(String, int, int) hashChars(input, 0, input.length())}.
      */
     public long hashChars(@NotNull String input) {
-        return stringHash.longHash(input, this, 0, input.length());
+        return VALID_STRING_HASH.longHash(input, this, 0, input.length());
     }
 
     /**
@@ -616,7 +557,7 @@ public abstract class LongHashFunction implements Serializable {
      */
     public long hashChars(@NotNull String input, int off, int len) {
         checkArrayOffs(input.length(), off, len);
-        return stringHash.longHash(input, this, off, len);
+        return VALID_STRING_HASH.longHash(input, this, off, len);
     }
 
     /**

--- a/src/main/java/net/openhft/hashing/LongHashFunction.java
+++ b/src/main/java/net/openhft/hashing/LongHashFunction.java
@@ -70,8 +70,8 @@ public abstract class LongHashFunction implements Serializable {
     private static final long serialVersionUID = 0L;
 
     static final boolean NATIVE_LITTLE_ENDIAN = nativeOrder() == LITTLE_ENDIAN;
-    private static final byte TRUE_BYTE_VALUE;
-    private static final byte FALSE_BYTE_VALUE;
+    static final byte TRUE_BYTE_VALUE;
+    static final byte FALSE_BYTE_VALUE;
 
     static {
         byte trueByteValue, falseByteValue;
@@ -248,7 +248,7 @@ public abstract class LongHashFunction implements Serializable {
      * @see #murmur_3(long)
      */
     public static LongHashFunction murmur_3() {
-        return MurmurHash_3.asLongHashFunctionWithoutSeed();
+        return MurmurHash_3.asLongTupleHashFunctionWithoutSeed();
     }
 
     /**
@@ -261,7 +261,7 @@ public abstract class LongHashFunction implements Serializable {
      * @see #murmur_3()
      */
     public static LongHashFunction murmur_3(long seed) {
-        return MurmurHash_3.asLongHashFunctionWithSeed(seed);
+        return MurmurHash_3.asLongTupleHashFunctionWithSeed(seed);
     }
 
     /**
@@ -340,7 +340,7 @@ public abstract class LongHashFunction implements Serializable {
         return MetroHash.asLongHashFunctionWithSeed(seed);
     }
 
-    private static StringHash stringHash;
+    static StringHash stringHash;
     static  {
         try {
             if (System.getProperty("java.vm.name").contains("HotSpot")) {
@@ -366,7 +366,7 @@ public abstract class LongHashFunction implements Serializable {
         }
     }
 
-    private static void checkArrayOffs(int arrayLength, int off, int len) {
+    static void checkArrayOffs(int arrayLength, int off, int len) {
         if (len < 0 || off < 0 || off + len > arrayLength || off + len < 0)
             throw new IndexOutOfBoundsException();
     }

--- a/src/main/java/net/openhft/hashing/LongHashFunction.java
+++ b/src/main/java/net/openhft/hashing/LongHashFunction.java
@@ -211,7 +211,7 @@ public abstract class LongHashFunction implements Serializable {
     }
 
     /**
-     * Returns a hash function implementing
+     * Returns a 64-bit hash function implementing
      * <a href="https://github.com/aappleby/smhasher/blob/master/src/MurmurHash3.cpp">MurmurHash3
      * algorithm</a> without seed values. This implementation produces equal results for equal input
      * on platforms with different {@link ByteOrder}, but is slower on big-endian platforms than on
@@ -224,7 +224,7 @@ public abstract class LongHashFunction implements Serializable {
     }
 
     /**
-     * Returns a hash function implementing
+     * Returns a 64-bit hash function implementing
      * <a href="https://github.com/aappleby/smhasher/blob/master/src/MurmurHash3.cpp">MurmurHash3
      * algorithm</a> with the given seed value. This implementation produces equal results for equal
      * input on platforms with different {@link ByteOrder}, but is slower on big-endian platforms

--- a/src/main/java/net/openhft/hashing/LongTupleHashFunction.java
+++ b/src/main/java/net/openhft/hashing/LongTupleHashFunction.java
@@ -12,6 +12,57 @@ import static net.openhft.hashing.CharSequenceAccess.nativeCharSequenceAccess;
 import static net.openhft.hashing.UnsafeAccess.*;
 import static net.openhft.hashing.Util.*;
 
+/**
+ * Tuple hash function producing {@code long[]} result from byte sequences of any length and
+ * a plenty of different sources which "feels like byte sequences". Except {@link
+ * #hashBytes(byte[])}, {@link #hashBytes(ByteBuffer)} (with their "sliced" versions) and
+ * {@link #hashMemory(long, long)} methods, which actually accept byte sequences, notion of byte
+ * sequence is defined as follows:
+ * <ul>
+ *     <li>For methods accepting arrays of Java primitives, {@code String}s and
+ *     {@code StringBuilder}s, byte sequence is how the input's bytes are actually lay in memory.
+ *     </li>
+ *     <li>For methods accepting single primitive values, byte sequence is how this primitive
+ *     would be put into memory with {@link ByteOrder#nativeOrder() native} byte order, or
+ *     equivalently, {@code hashXxx(primitive)} has always the same result as {@code
+ *     hashXxxs(new xxx[] {primitive})}, where "xxx" is any Java primitive type name.</li>
+ *     <li>For {@link #hash(Object, Access, long, long)} method byte sequence abstraction
+ *     is defined by the given {@link Access} strategy to the given object.</li>
+ * </ul>
+ *
+ * <p>Tuple hash function implementation could either produce equal results for equal input on platforms
+ * with different {@link ByteOrder}, favoring one byte order in terms of performance, or different
+ * results, but performing equally good. This choice should be explicitly documented for all
+ * {@code LongTupleHashFunction} implementations.
+ *
+ * Each hash api have two forms:
+ * <ul>
+ *     <li> {code void hash(input..., long[] result)} will put the hash result in array {@code result}
+ *     <li> {code long[] hash(input...)} will alloc and return an array container the results
+ * </ul>
+ * ${@code newResultArray()} api should always be used to create resuable result arrays. And a hash
+ * implementation can omit checking the length of result arrays for better performance.
+ *
+ * <h3>Subclassing</h3>
+ * To implement a specific hash function algorithm resulting more than 64 bits results,
+ * this class should be subclassed. Only methods with resued result array that accept single primitives,
+ * {@link #hashVoid(long[])} and {@link #hash(Object, Access, long, long, long[])} should be implemented;
+ * other have default implementations which in the end delegate to
+ * {@link #hash(Object, Access, long, long, long[])} abstract method.
+ *
+ * The {@code #bitsLength()} method should also be implemented, returning the actual bits in the result
+ * array. The bits length should be greater than 64, otherwise just using the {@link #LongHashFunction}
+ * interface. And the length should also be a positive multiple of 8.
+ *
+ * <p>Notes about how exactly methods with default implementations are implemented in doc comments
+ * are given for information and could be changed at any moment. However, it could hardly cause
+ * any issues with subclassing, except probably little performance degradation. Methods documented
+ * as "shortcuts" could either delegate to the referenced method or delegate directly to the method
+ * to which the referenced method delegates.
+ *
+ *<p>{@code LongTupleHashFunction} implementations shouldn't assume that {@code Access} strategies
+ * do defensive checks, and access only bytes within the requested range.
+ */
 @ParametersAreNonnullByDefault
 public abstract class LongTupleHashFunction implements Serializable {
     private static final long serialVersionUID = 0L;
@@ -20,7 +71,7 @@ public abstract class LongTupleHashFunction implements Serializable {
     //
 
     /**
-     * Returns a hash function implementing
+     * Returns a 128-bit hash function implementing
      * <a href="https://github.com/aappleby/smhasher/blob/master/src/MurmurHash3.cpp">MurmurHash3
      * algorithm</a> without seed values. This implementation produces equal results for equal input
      * on platforms with different {@link ByteOrder}, but is slower on big-endian platforms than on
@@ -34,7 +85,7 @@ public abstract class LongTupleHashFunction implements Serializable {
     }
 
     /**
-     * Returns a hash function implementing
+     * Returns a 128-bit hash function implementing
      * <a href="https://github.com/aappleby/smhasher/blob/master/src/MurmurHash3.cpp">MurmurHash3
      * algorithm</a> with the given seed value. This implementation produces equal results for equal
      * input on platforms with different {@link ByteOrder}, but is slower on big-endian platforms
@@ -47,6 +98,11 @@ public abstract class LongTupleHashFunction implements Serializable {
         return MurmurHash_3.asLongTupleHashFunctionWithSeed(seed);
     }
 
+    /**
+     * Constructor for use in subclasses.
+     */
+    protected LongTupleHashFunction() {}
+
     // Public API
     //
 
@@ -56,14 +112,25 @@ public abstract class LongTupleHashFunction implements Serializable {
     public abstract int bitsLength();
 
     /**
-     * Returns an empty result array
+     * Returns a result array
      */
     @NotNull
     public long[] newResultArray() {
         return new long[(bitsLength() + 63) / 64];
     }
 
+    /**
+     * Returns the hash code for the given {@code long} value; this method is consistent with
+     * {@code LongTupleHashFunction} methods that accept sequences of bytes, assuming the {@code input}
+     * value is interpreted in {@linkplain ByteOrder#nativeOrder() native} byte order. For example,
+     * the result of {@code hashLong(v, result)} call is identical to the result of
+     * {@code hashLongs(new long[] {v}, result)} call for any {@code long} value.
+     */
     public abstract void hashLong(long input, long[] result);
+
+    /**
+     * See {@link #hashLong(long, long[])}
+     */
     @NotNull
     public long[] hashLong(final long input) {
         final long[] result = newResultArray();
@@ -71,7 +138,18 @@ public abstract class LongTupleHashFunction implements Serializable {
         return result;
     }
 
+    /**
+     * Returns the hash code for the given {@code int} value; this method is consistent with
+     * {@code LongTupleHashFunction} methods that accept sequences of bytes, assuming the {@code input}
+     * value is interpreted in {@linkplain ByteOrder#nativeOrder() native} byte order. For example,
+     * the result of {@code hashInt(v, result)} call is identical to the result of
+     * {@code hashInts(new int[] {v}, result)} call for any {@code int} value.
+     */
     public abstract void hashInt(int input, long[] result);
+
+    /**
+     * See {@link #hashInt(int, long[])}
+     */
     @NotNull
     public long[] hashInt(final int input) {
         final long[] result = newResultArray();
@@ -79,7 +157,20 @@ public abstract class LongTupleHashFunction implements Serializable {
         return result;
     }
 
+    /**
+     * Returns the hash code for the given {@code short} value; this method is consistent with
+     * {@code LongTupleHashFunction} methods that accept sequences of bytes, assuming the {@code input}
+     * value is interpreted in {@linkplain ByteOrder#nativeOrder() native} byte order. For example,
+     * the result of {@code hashShort(v, result)} call is identical to the result of
+     * {@code hashShorts(new short[] {v}, result)} call for any {@code short} value.
+     * As a consequence, {@code hashShort(v, result)} call produce always the same result as {@code
+     * hashChar((char) v, result)}.
+     */
     public abstract void hashShort(short input, long[] result);
+
+    /**
+     * See {@link #hashShort(short, long[])}
+     */
     @NotNull
     public long[] hashShort(final short input) {
         final long[] result = newResultArray();
@@ -87,7 +178,20 @@ public abstract class LongTupleHashFunction implements Serializable {
         return result;
     }
 
+    /**
+     * Returns the hash code for the given {@code char} value; this method is consistent with
+     * {@code LongTupleHashFunction} methods that accept sequences of bytes, assuming the {@code input}
+     * value is interpreted in {@linkplain ByteOrder#nativeOrder() native} byte order. For example,
+     * the result of {@code hashChar(v, result)} call is identical to the result of
+     * {@code hashChars(new char[] {v}, result)} call for any {@code char} value.
+     * As a consequence, {@code hashChar(v, result)} call produce always the same result as {@code
+     * hashShort((short) v, result)}.
+     */
     public abstract void hashChar(char input, long[] result);
+
+    /**
+     * See {@link #hashChar(char, long[])}
+     */
     @NotNull
     public long[] hashChar(final char input) {
         final long[] result = newResultArray();
@@ -95,7 +199,17 @@ public abstract class LongTupleHashFunction implements Serializable {
         return result;
     }
 
+    /**
+     * Returns the hash code for the given {@code byte} value. This method is consistent with
+     * {@code LongTupleHashFunction} methods that accept sequences of bytes. For example, the result of
+     * {@code hashByte(v, result)} call is identical to the result of
+     * {@code hashBytes(new byte[] {v}, result)} call for any {@code byte} value.
+     */
     public abstract void hashByte(byte input, long[] result);
+
+    /**
+     * See {@link #hashByte(byte, long[])}
+     */
     @NotNull
     public long[] hashByte(final byte input) {
         final long[] result = newResultArray();
@@ -103,7 +217,15 @@ public abstract class LongTupleHashFunction implements Serializable {
         return result;
     }
 
+    /**
+     * Returns the hash code for the empty (zero-length) bytes sequence,
+     * for example {@code hashBytes(new byte[0], result)}.
+     */
     public abstract void hashVoid(long[] result);
+
+    /**
+     * See {@link #hashVoid(long[])}
+     */
     @NotNull
     public long[] hashVoid() {
         final long[] result = newResultArray();
@@ -111,7 +233,29 @@ public abstract class LongTupleHashFunction implements Serializable {
         return result;
     }
 
+    /**
+     * Returns the hash code for {@code len} continuous bytes of the given {@code input} object,
+     * starting from the given offset. The abstraction of input as ordered byte sequence and
+     * "offset within the input" is defined by the given {@code access} strategy.
+     *
+     * <p>This method doesn't promise to throw a {@code RuntimeException} if {@code
+     * [off, off + len - 1]} subsequence exceeds the bounds of the bytes sequence, defined by {@code
+     * access} strategy for the given {@code input}, so use this method with caution.
+     *
+     * @param input the object to read bytes from
+     * @param access access which defines the abstraction of the given input
+     *               as ordered byte sequence
+     * @param off offset to the first byte of the subsequence to hash
+     * @param len length of the subsequence to hash
+     * @param result the container array for putting the hash results,
+     *               should be alloced by ${@code #newResultArray()}
+     * @param <T> the type of the input
+     */
     public abstract <T> void hash(@Nullable T input, Access<T> access, long off, long len, long[] result);
+
+    /**
+     * See {@link #hash(T, Access, long, long, long[])}
+     */
     @NotNull
     public <T> long[] hash(@Nullable final T input, final Access<T> access, final long off, final long len) {
         final long[] result = newResultArray();
@@ -119,9 +263,18 @@ public abstract class LongTupleHashFunction implements Serializable {
         return result;
     }
 
+    /**
+     * Shortcut for {@link #hashBooleans(boolean[], long[]) hashBooleans(new boolean[] &#123;input&#125;, result)}.
+     * Note that this is not necessarily equal to {@code hashByte(input ? (byte) 1 : (byte) 0, result)},
+     * because booleans could be stored differently in this JVM.
+     */
     public void hashBoolean(final boolean input, final long[] result) {
         hashByte(input ? TRUE_BYTE_VALUE : FALSE_BYTE_VALUE, result);
     }
+
+    /**
+     * See {@link #hashBoolean(boolean, long[])}
+     */
     @NotNull
     public long[] hashBoolean(final boolean input) {
         final long[] result = newResultArray();
@@ -129,9 +282,16 @@ public abstract class LongTupleHashFunction implements Serializable {
         return result;
     }
 
+    /**
+     * Shortcut for {@link #hashBooleans(boolean[], int, int, long[]) hashBooleans(input, 0, input.length, result)}.
+     */
     public void hashBooleans(final boolean[] input, final long[] result) {
         unsafeHash(this, input, BOOLEAN_BASE, input.length, result);
     }
+
+    /**
+     * See {@link #hashBooleans(boolean[], long[])}
+     */
     @NotNull
     public long[] hashBooleans(final boolean[] input) {
         final long[] result = newResultArray();
@@ -139,10 +299,28 @@ public abstract class LongTupleHashFunction implements Serializable {
         return result;
     }
 
+    /**
+     * Returns the hash code for the specified subsequence of the given {@code boolean} array.
+     *
+     * <p>Default implementation delegates to {@link #hash(Object, Access, long, long, long[])} method
+     * using {@linkplain Access#unsafe() unsafe} {@code Access}.
+     *
+     * @param input the array to read data from
+     * @param off index of the first {@code boolean} in the subsequence to hash
+     * @param len length of the subsequence to hash
+     * @param result the container array for putting the hash results,
+     *               should be alloced by ${@code #newResultArray()}
+     * @throws IndexOutOfBoundsException if {@code off < 0} or {@code off + len > input.length}
+     * or {@code len < 0}
+     */
     public void hashBooleans(final boolean[] input, final int off, final int len, final long[] result) {
         checkArrayOffs(input.length, off, len);
         unsafeHash(this, input, BOOLEAN_BASE + off, len, result);
     }
+
+    /**
+     * See {@link #hashBooleans(boolean[], int, int, long[])}
+     */
     @NotNull
     public long[] hashBooleans(final boolean[] input, final int off, final int len) {
         checkArrayOffs(input.length, off, len);
@@ -151,9 +329,16 @@ public abstract class LongTupleHashFunction implements Serializable {
         return result;
     }
 
+    /**
+     * Shortcut for {@link #hashBytes(byte[], int, int, long[]) hashBytes(input, 0, input.length, result)}.
+     */
     public void hashBytes(final byte[] input, final long[] result) {
         unsafeHash(this, input, BYTE_BASE, input.length, result);
     }
+
+    /**
+     * See {@link #hashBytes(byte[], long[])}
+     */
     @NotNull
     public long[] hashBytes(final byte[] input) {
         final long[] result = newResultArray();
@@ -161,10 +346,28 @@ public abstract class LongTupleHashFunction implements Serializable {
         return result;
     }
 
+    /**
+     * Returns the hash code for the specified subsequence of the given {@code byte} array.
+     *
+     * <p>Default implementation delegates to {@link #hash(Object, Access, long, long, long[])}
+     * method using {@linkplain Access#unsafe() unsafe} {@code Access}.
+     *
+     * @param input the array to read bytes from
+     * @param off index of the first {@code byte} in the subsequence to hash
+     * @param len length of the subsequence to hash
+     * @param result the container array for putting the hash results,
+     *               should be alloced by ${@code #newResultArray()}
+     * @throws IndexOutOfBoundsException if {@code off < 0} or {@code off + len > input.length}
+     * or {@code len < 0}
+     */
     public void hashBytes(final byte[] input, final int off, final int len, final long[] result) {
         checkArrayOffs(input.length, off, len);
         unsafeHash(this, input, BYTE_BASE + off, len, result);
     }
+
+    /**
+     * See {@link #hashBytes(byte[], int, int, long[])}
+     */
     @NotNull
     public long[] hashBytes(final byte[] input, final int off, final int len) {
         checkArrayOffs(input.length, off, len);
@@ -173,9 +376,17 @@ public abstract class LongTupleHashFunction implements Serializable {
         return result;
     }
 
+    /**
+     * Shortcut for {@link #hashBytes(ByteBuffer, int, int, long[])
+     * hashBytes(input, input.position(), input.remaining(), result)}.
+     */
     public void hashBytes(final ByteBuffer input, final long[] result) {
         hashByteBuffer(this, input, input.position(), input.remaining(), result);
     }
+
+    /**
+     * See {@link #hashBytes(ByteBuffer, long[])}
+     */
     @NotNull
     public long[] hashBytes(final ByteBuffer input) {
         final long[] result = newResultArray();
@@ -183,10 +394,31 @@ public abstract class LongTupleHashFunction implements Serializable {
         return result;
     }
 
+    /**
+     * Returns the hash code for the specified subsequence of the given {@code ByteBuffer}.
+     *
+     * <p>This method doesn't alter the state (mark, position, limit or order) of the given
+     * {@code ByteBuffer}.
+     *
+     * <p>Default implementation delegates to {@link #hash(Object, Access, long, long, long[])}
+     * method using {@link Access#toByteBuffer()}.
+     *
+     * @param input the buffer to read bytes from
+     * @param off index of the first {@code byte} in the subsequence to hash
+     * @param len length of the subsequence to hash
+     * @param result the container array for putting the hash results,
+     *               should be alloced by ${@code #newResultArray()}
+     * @throws IndexOutOfBoundsException if {@code off < 0} or {@code off + len > input.capacity()}
+     * or {@code len < 0}
+     */
     public void hashBytes(final ByteBuffer input, final int off, final int len, final long[] result) {
         checkArrayOffs(input.capacity(), off, len);
         hashByteBuffer(this, input, off, len, result);
     }
+
+    /**
+     * See {@link #hashBytes(ByteBuffer, int, int, long[])}
+     */
     @NotNull
     public long[] hashBytes(final ByteBuffer input, final int off, final int len) {
         checkArrayOffs(input.capacity(), off, len);
@@ -195,9 +427,24 @@ public abstract class LongTupleHashFunction implements Serializable {
         return result;
     }
 
+    /**
+     * Returns the hash code of bytes of the wild memory from the given address. Use with caution.
+     *
+     * <p>Default implementation delegates to {@link #hash(Object, Access, long, long, long[])}
+     * method using {@linkplain Access#unsafe() unsafe} {@code Access}.
+     *
+     * @param address the address of the first byte to hash
+     * @param len length of the byte sequence to hash
+     * @param result the container array for putting the hash results,
+     *               should be alloced by ${@code #newResultArray()}
+     */
     public void hashMemory(final long address, final long len, final long[] result) {
         unsafeHash(this, null, address, len, result);
     }
+
+    /**
+     * See {@link #hashMemory(long, long, long[])}
+     */
     @NotNull
     public long[] hashMemory(final long address, final long len) {
         final long[] result = newResultArray();
@@ -205,9 +452,16 @@ public abstract class LongTupleHashFunction implements Serializable {
         return result;
     }
 
+    /**
+     * Shortcut for {@link #hashChars(char[], int, int, long[]) hashChars(input, 0, input.length, result)}.
+     */
     public void hashChars(final char[] input, final long[] result) {
         unsafeHash(this, input, CHAR_BASE, input.length * 2L, result);
     }
+
+    /**
+     * See {@link #hashChars(char[], long[])}
+     */
     @NotNull
     public long[] hashChars(final char[] input) {
         final long[] result = newResultArray();
@@ -215,10 +469,30 @@ public abstract class LongTupleHashFunction implements Serializable {
         return result;
     }
 
+    /**
+     * Returns the hash code for bytes, as they lay in memory, of the specified subsequence
+     * of the given {@code char} array.
+     *
+     * <p>Default implementation delegates to {@link #hash(Object, Access, long, long, long[])}
+     * method using {@linkplain Access#unsafe() unsafe} {@code Access}.
+     *
+     * @param input the array to read data from
+     * @param off index of the first {@code char} in the subsequence to hash
+     * @param len length of the subsequence to hash, in chars (i. e. the length of the bytes
+     *            sequence to hash is {@code len * 2L})
+     * @param result the container array for putting the hash results,
+     *               should be alloced by ${@code #newResultArray()}
+     * @throws IndexOutOfBoundsException if {@code off < 0} or {@code off + len > input.length}
+     * or {@code len < 0}
+     */
     public void hashChars(final char[] input, final int off, final int len, final long[] result) {
         checkArrayOffs(input.length, off, len);
         unsafeHash(this, input, CHAR_BASE + (off * 2L), len * 2L, result);
     }
+
+    /**
+     * See {@link #hashChars(char[], int, int, long[])}
+     */
     @NotNull
     public long[] hashChars(final char[] input, final int off, final int len) {
         checkArrayOffs(input.length, off, len);
@@ -227,9 +501,16 @@ public abstract class LongTupleHashFunction implements Serializable {
         return result;
     }
 
+    /**
+     * Shortcut for {@link #hashChars(String, int, int, long[]) hashChars(input, 0, input.length(), result)}.
+     */
     public void hashChars(final String input, final long[] result) {
         VALID_STRING_HASH.hash(input, this, 0, input.length(), result);
     }
+
+    /**
+     * See {@link #hashChars(String, long[])}
+     */
     @NotNull
     public long[] hashChars(final String input) {
         final long[] result = newResultArray();
@@ -237,10 +518,30 @@ public abstract class LongTupleHashFunction implements Serializable {
         return result;
     }
 
+    /**
+     * Returns the hash code for bytes of the specified subsequence of the given {@code String}'s
+     * underlying {@code char} array.
+     *
+     * <p>Default implementation could either delegate to {@link #hash(Object, Access, long, long, long[])}
+     * using {@link Access#toNativeCharSequence()}, or to {@link #hashChars(char[], int, int, long[])}.
+     *
+     * @param input the string which bytes to hash
+     * @param off index of the first {@code char} in the subsequence to hash
+     * @param len length of the subsequence to hash, in chars (i. e. the length of the bytes
+     *            sequence to hash is {@code len * 2L})
+     * @param result the container array for putting the hash results,
+     *               should be alloced by ${@code #newResultArray()}
+     * @throws IndexOutOfBoundsException if {@code off < 0} or {@code off + len > input.length()}
+     * or {@code len < 0}
+     */
     public void hashChars(final String input, final int off, final int len, final long[] result) {
         checkArrayOffs(input.length(), off, len);
         VALID_STRING_HASH.hash(input, this, off, len, result);
     }
+
+    /**
+     * See {@link #hashChars(String, int, int long[])}
+     */
     @NotNull
     public long[] hashChars(final String input, final int off, final int len) {
         checkArrayOffs(input.length(), off, len);
@@ -249,9 +550,16 @@ public abstract class LongTupleHashFunction implements Serializable {
         return result;
     }
 
+    /**
+     * Shortcut for {@link #hashChars(T, int, int, result) hashChars(input, 0, input.length(), result)}.
+     */
     public <T extends CharSequence> void hashChars(final T input, final long[] result) {
         hashNativeChars(this, input, 0, input.length(), result);
     }
+
+    /**
+     * See {@link #hashChars(T, long[])}
+     */
     @NotNull
     public <T extends CharSequence> long[] hashChars(final T input) {
         final long[] result = newResultArray();
@@ -259,10 +567,31 @@ public abstract class LongTupleHashFunction implements Serializable {
         return result;
     }
 
+    /**
+     * Returns the hash code for bytes of the specified subsequence of the given
+     * {@code CharSequence}'s underlying {@code char} array.
+     *
+     * <p>Default implementation could either delegate to {@link #hash(Object, Access, long, long, result)}
+     * using {@link Access#toNativeCharSequence()}.
+     *
+     * @param input the char sequence which bytes to hash
+     * @param off index of the first {@code char} in the subsequence to hash
+     * @param len length of the subsequence to hash, in chars (i. e. the length of the bytes
+     *            sequence to hash is {@code len * 2L})
+     * @param result the container array for putting the hash results,
+     *               should be alloced by ${@code #newResultArray()}
+     * @param <T> the type of the input which extends CharSequence
+     * @throws IndexOutOfBoundsException if {@code off < 0} or {@code off + len > input.length()}
+     * or {@code len < 0}
+     */
     public <T extends CharSequence> void hashChars(final T input, final int off, final int len, final long[] result) {
         checkArrayOffs(input.length(), off, len);
         hashNativeChars(this, input, off, len, result);
     }
+
+    /**
+     * See {@link #hashChars(T, int, int, long[])}
+     */
     @NotNull
     public <T extends CharSequence> long[] hashChars(final T input, final int off, final int len) {
         checkArrayOffs(input.length(), off, len);
@@ -271,9 +600,16 @@ public abstract class LongTupleHashFunction implements Serializable {
         return result;
     }
 
+    /**
+     * Shortcut for {@link #hashShorts(short[], int, int, long[]) hashShorts(input, 0, input.length, result)}.
+     */
     public void hashShorts(final short[] input, final long[] result) {
         unsafeHash(this, input, SHORT_BASE, input.length * 2L, result);
     }
+
+    /**
+     * See {@link #hashShorts(short[], long[])}
+     */
     @NotNull
     public long[] hashShorts(final short[] input) {
         final long[] result = newResultArray();
@@ -281,10 +617,30 @@ public abstract class LongTupleHashFunction implements Serializable {
         return result;
     }
 
+    /**
+     * Returns the hash code for bytes, as they lay in memory, of the specified subsequence
+     * of the given {@code short} array.
+     *
+     * <p>Default implementation delegates to {@link #hash(Object, Access, long, long, long[])}
+     * method using {@linkplain Access#unsafe() unsafe} {@code Access}.
+     *
+     * @param input the array to read data from
+     * @param off index of the first {@code short} in the subsequence to hash
+     * @param len length of the subsequence to hash, in shorts (i. e. the length of the bytes
+     *            sequence to hash is {@code len * 2L})
+     * @param result the container array for putting the hash results,
+     *               should be alloced by ${@code #newResultArray()}
+     * @throws IndexOutOfBoundsException if {@code off < 0} or {@code off + len > input.length}
+     * or {@code len < 0}
+     */
     public void hashShorts(final short[] input, final int off, final int len, final long[] result) {
         checkArrayOffs(input.length, off, len);
         unsafeHash(this, input, SHORT_BASE + (off * 2L), len * 2L, result);
     }
+
+    /**
+     * See {@link #hashShorts(short[], int, int, long[])}
+     */
     @NotNull
     public long[] hashShorts(final short[] input, final int off, final int len) {
         checkArrayOffs(input.length, off, len);
@@ -293,9 +649,16 @@ public abstract class LongTupleHashFunction implements Serializable {
         return result;
     }
 
+    /**
+     * Shortcut for {@link #hashInts(int[], int, int, long[]) hashInts(input, 0, input.length, result)}.
+     */
     public void hashInts(final int[] input, final long[] result) {
         unsafeHash(this, input, INT_BASE, input.length * 4L, result);
     }
+
+    /**
+     * See {@link #hashInts(int[], long[])}
+     */
     @NotNull
     public long[] hashInts(final int[] input) {
         final long[] result = newResultArray();
@@ -303,10 +666,30 @@ public abstract class LongTupleHashFunction implements Serializable {
         return result;
     }
 
+    /**
+     * Returns the hash code for bytes, as they lay in memory, of the specified subsequence
+     * of the given {@code int} array.
+     *
+     * <p>Default implementation delegates to {@link #hash(Object, Access, long, long, long[])}
+     * method using {@linkplain Access#unsafe() unsafe} {@code Access}.
+     *
+     * @param input the array to read data from
+     * @param off index of the first {@code int} in the subsequence to hash
+     * @param len length of the subsequence to hash, in ints (i. e. the length of the bytes
+     *            sequence to hash is {@code len * 4L})
+     * @param result the container array for putting the hash results,
+     *               should be alloced by ${@code #newResultArray()}
+     * @throws IndexOutOfBoundsException if {@code off < 0} or {@code off + len > input.length}
+     * or {@code len < 0}
+     */
     public void hashInts(final int[] input, final int off, final int len, final long[] result) {
         checkArrayOffs(input.length, off, len);
         unsafeHash(this, input, INT_BASE + (off * 4L), len * 4L, result);
     }
+
+    /**
+     * See {@link #hashInts(int[], int, int, long[])}
+     */
     @NotNull
     public long[] hashInts(final int[] input, final int off, final int len) {
         checkArrayOffs(input.length, off, len);
@@ -315,9 +698,16 @@ public abstract class LongTupleHashFunction implements Serializable {
         return result;
     }
 
+    /**
+     * Shortcut for {@link #hashLongs(long[], int, int, long[]) hashLongs(input, 0, input.length, result)}.
+     */
     public void hashLongs(final long[] input, final long[] result) {
         unsafeHash(this, input, LONG_BASE, input.length * 8L, result);
     }
+
+    /**
+     * See {@link #hashLongs(long[], long[])}
+     */
     @NotNull
     public long[] hashLongs(final long[] input) {
         final long[] result = newResultArray();
@@ -325,10 +715,30 @@ public abstract class LongTupleHashFunction implements Serializable {
         return result;
     }
 
+    /**
+     * Returns the hash code for bytes, as they lay in memory, of the specified subsequence
+     * of the given {@code long} array.
+     *
+     * <p>Default implementation delegates to {@link #hash(Object, Access, long, long, long[])}
+     * method using {@linkplain Access#unsafe() unsafe} {@code Access}.
+     *
+     * @param input the array to read data from
+     * @param off index of the first {@code long} in the subsequence to hash
+     * @param len length of the subsequence to hash, in longs (i. e. the length of the bytes
+     *            sequence to hash is {@code len * 8L})
+     * @param result the container array for putting the hash results,
+     *               should be alloced by ${@code #newResultArray()}
+     * @throws IndexOutOfBoundsException if {@code off < 0} or {@code off + len > input.length}
+     * or {@code len < 0}
+     */
     public void hashLongs(final long[] input, final int off, final int len, final long[] result) {
         checkArrayOffs(input.length, off, len);
         unsafeHash(this, input, LONG_BASE + (off * 8L), len * 8L, result);
     }
+
+    /**
+     * See {@link #hashLongs(long[], int, int, long[])}
+     */
     @NotNull
     public long[] hashLongs(final long[] input, final int off, final int len) {
         checkArrayOffs(input.length, off, len);
@@ -366,5 +776,4 @@ public abstract class LongTupleHashFunction implements Serializable {
                     final int off, final int len, final long[] result) {
         f.hash(input, CHAR_SEQ_ACCESS, off * 2L, len * 2L, result);
     }
-
 }

--- a/src/main/java/net/openhft/hashing/LongTupleHashFunction.java
+++ b/src/main/java/net/openhft/hashing/LongTupleHashFunction.java
@@ -121,7 +121,7 @@ public abstract class LongTupleHashFunction implements Serializable {
      * {@code result.length > newResultArray().length]}.
      *
      * @throws NullPointerException if {@code result == null}
-     * @throws IndexOutOfBoundsException if {@code result.length < newResultArray().length}
+     * @throws IllegalArgumentException if {@code result.length < newResultArray().length}
      */
     public abstract void hashLong(long input, long[] result);
 
@@ -151,7 +151,7 @@ public abstract class LongTupleHashFunction implements Serializable {
      * {@code result.length > newResultArray().length]}.
      *
      * @throws NullPointerException if {@code result == null}
-     * @throws IndexOutOfBoundsException if {@code result.length < newResultArray().length}
+     * @throws IllegalArgumentException if {@code result.length < newResultArray().length}
      */
     public abstract void hashInt(int input, long[] result);
 
@@ -181,7 +181,7 @@ public abstract class LongTupleHashFunction implements Serializable {
      * {@code result.length > newResultArray().length]}.
      *
      * @throws NullPointerException if {@code result == null}
-     * @throws IndexOutOfBoundsException if {@code result.length < newResultArray().length}
+     * @throws IllegalArgumentException if {@code result.length < newResultArray().length}
      */
     public abstract void hashShort(short input, long[] result);
 
@@ -344,7 +344,7 @@ public abstract class LongTupleHashFunction implements Serializable {
      * @param len length of the subsequence to hash
      * @param result the container array for putting the hash results,
      *               should be alloced by {@link #newResultArray}
-     * @throws IndexOutOfBoundsException if {@code off < 0} or {@code off + len > input.length}
+     * @throws IllegalArgumentException if {@code off < 0} or {@code off + len > input.length}
      * or {@code len < 0}
      */
     public void hashBooleans(final boolean[] input,
@@ -396,7 +396,7 @@ public abstract class LongTupleHashFunction implements Serializable {
      * @param len length of the subsequence to hash
      * @param result the container array for putting the hash results,
      *               should be alloced by {@link #newResultArray}
-     * @throws IndexOutOfBoundsException if {@code off < 0} or {@code off + len > input.length}
+     * @throws IllegalArgumentException if {@code off < 0} or {@code off + len > input.length}
      * or {@code len < 0}
      */
     public void hashBytes(final byte[] input, final int off, final int len, final long[] result) {
@@ -451,7 +451,7 @@ public abstract class LongTupleHashFunction implements Serializable {
      * @param len length of the subsequence to hash
      * @param result the container array for putting the hash results,
      *               should be alloced by {@link #newResultArray}
-     * @throws IndexOutOfBoundsException if {@code off < 0} or {@code off + len > input.capacity()}
+     * @throws IllegalArgumentException if {@code off < 0} or {@code off + len > input.capacity()}
      * or {@code len < 0}
      */
     public void hashBytes(final ByteBuffer input,
@@ -532,7 +532,7 @@ public abstract class LongTupleHashFunction implements Serializable {
      *            sequence to hash is {@code len * 2L})
      * @param result the container array for putting the hash results,
      *               should be alloced by {@link #newResultArray}
-     * @throws IndexOutOfBoundsException if {@code off < 0} or {@code off + len > input.length}
+     * @throws IllegalArgumentException if {@code off < 0} or {@code off + len > input.length}
      * or {@code len < 0}
      */
     public void hashChars(final char[] input, final int off, final int len, final long[] result) {
@@ -585,7 +585,7 @@ public abstract class LongTupleHashFunction implements Serializable {
      *            sequence to hash is {@code len * 2L})
      * @param result the container array for putting the hash results,
      *               should be alloced by {@link #newResultArray}
-     * @throws IndexOutOfBoundsException if {@code off < 0} or {@code off + len > input.length()}
+     * @throws IllegalArgumentException if {@code off < 0} or {@code off + len > input.length()}
      * or {@code len < 0}
      */
     public void hashChars(final String input, final int off, final int len, final long[] result) {
@@ -639,7 +639,7 @@ public abstract class LongTupleHashFunction implements Serializable {
      * @param result the container array for putting the hash results,
      *               should be alloced by {@link #newResultArray}
      * @param <T> the type of the input which extends CharSequence
-     * @throws IndexOutOfBoundsException if {@code off < 0} or {@code off + len > input.length()}
+     * @throws IllegalArgumentException if {@code off < 0} or {@code off + len > input.length()}
      * or {@code len < 0}
      */
     public <T extends CharSequence> void hashChars(final T input, final int off, final int len,
@@ -693,7 +693,7 @@ public abstract class LongTupleHashFunction implements Serializable {
      *            sequence to hash is {@code len * 2L})
      * @param result the container array for putting the hash results,
      *               should be alloced by {@link #newResultArray}
-     * @throws IndexOutOfBoundsException if {@code off < 0} or {@code off + len > input.length}
+     * @throws IllegalArgumentException if {@code off < 0} or {@code off + len > input.length}
      * or {@code len < 0}
      */
     public void hashShorts(final short[] input, final int off, final int len, final long[] result) {
@@ -746,7 +746,7 @@ public abstract class LongTupleHashFunction implements Serializable {
      *            sequence to hash is {@code len * 4L})
      * @param result the container array for putting the hash results,
      *               should be alloced by {@link #newResultArray}
-     * @throws IndexOutOfBoundsException if {@code off < 0} or {@code off + len > input.length}
+     * @throws IllegalArgumentException if {@code off < 0} or {@code off + len > input.length}
      * or {@code len < 0}
      */
     public void hashInts(final int[] input, final int off, final int len, final long[] result) {
@@ -799,7 +799,7 @@ public abstract class LongTupleHashFunction implements Serializable {
      *            sequence to hash is {@code len * 8L})
      * @param result the container array for putting the hash results,
      *               should be alloced by {@link #newResultArray}
-     * @throws IndexOutOfBoundsException if {@code off < 0} or {@code off + len > input.length}
+     * @throws IllegalArgumentException if {@code off < 0} or {@code off + len > input.length}
      * or {@code len < 0}
      */
     public void hashLongs(final long[] input, final int off, final int len, final long[] result) {

--- a/src/main/java/net/openhft/hashing/LongTupleHashFunction.java
+++ b/src/main/java/net/openhft/hashing/LongTupleHashFunction.java
@@ -17,25 +17,25 @@ import static net.openhft.hashing.Util.*;
  * {@code long[]} from any byte sequences. See {@link LongHashFunction} for the definition of byte
  * sequence semantics and {@link ByteOrder} requirements for implementations.
  *
- * Every {#link LongHashFunction} hash method has two corresponding ones in this class for different
- * allocation stradges:
+ * Every {@link LongHashFunction} hash method has two corresponding ones in this class for different
+ * allocation strategies:
  * <ul>
  *     <li>{@code void hash(input..., long[] result)} will store the hash results in array
- *     {@code result[0 .. newResultArray().length-1]}, and throws exceptions when {@code result}
- *     is not valid. {@link #newResultArray} method should always be used to create resuable result
- *     arrays to avoid exceptions. See {@link #hash(long, long[])}.</li>
+ *     {@code result[0 .. newResultArray().length-1]}, and throws exceptions when
+ *     {@code result == null} or the length of the array is less than
+ *     {@code newResultArray().length}. {@link #newResultArray} method should always be used to
+ *     create resuable result arrays to avoid exceptions. See {@link #hashLong(long, long[])}.</li>
  *     <li>{@code long[] hash(input...)} will allocate and return an array containing the results.
  *     </li>
  * </ul>
  *
- * <b>Warning:</b> Allocations <strong>cannot</strong> be totally avoid to exchange a more than
- * 64-bit result since there is no value type in java yet. For the first form of a hash method, a
- * single allocation occurs only at the begining of some runtime scope, so it could be called
+ * <p><b>Warning:</b> For the first form of a hash method, a single allocation occurs only at the
+ * begining of some runtime scope, so it could be called
  * <strong>Almost-Zero-Allocation-Hashing</strong>.
  *
- * <b>Warning:</b> The second form <strong>always performs exactly one allocation</strong> for the
- * result array in each invocation, that is <strong>One-Allocation-Hashing</strong>. So prefer the
- * first form as much as possible.
+ * <p><b>Warning:</b> The second form <strong>always performs exactly one allocation</strong> for
+ * the result array in each invocation, that is <strong>One-Allocation-Hashing</strong>. So prefer
+ * the first form as much as possible.
  *
  * <h3>Subclassing</h3>
  * To implement a specific hash function algorithm resulting more than 64 bits results, this class

--- a/src/main/java/net/openhft/hashing/LongTupleHashFunction.java
+++ b/src/main/java/net/openhft/hashing/LongTupleHashFunction.java
@@ -13,55 +13,43 @@ import static net.openhft.hashing.UnsafeAccess.*;
 import static net.openhft.hashing.Util.*;
 
 /**
- * Tuple hash function producing {@code long[]} result from byte sequences of any length and
- * a plenty of different sources which "feels like byte sequences". Except {@link
- * #hashBytes(byte[])}, {@link #hashBytes(ByteBuffer)} (with their "sliced" versions) and
- * {@link #hashMemory(long, long)} methods, which actually accept byte sequences, notion of byte
- * sequence is defined as follows:
+ * Tuple hash function producing more than 64-bit hash code into a result array of type
+ * {@code long[]} from any byte sequences. See {@link LongHashFunction} for the definition of byte
+ * sequence semantics and {@link ByteOrder} requirements for implementations.
+ *
+ * Every {#link LongHashFunction} hash method has two corresponding ones in this class for different
+ * allocation stradges:
  * <ul>
- *     <li>For methods accepting arrays of Java primitives, {@code String}s and
- *     {@code StringBuilder}s, byte sequence is how the input's bytes are actually lay in memory.
+ *     <li>{@code void hash(input..., long[] result)} will store the hash results in array
+ *     {@code result[0 .. newResultArray().length-1]}, and throws exceptions when {@code result}
+ *     is not valid. {@link #newResultArray} method should always be used to create resuable result
+ *     arrays to avoid exceptions. See {@link #hash(long, long[])}.</li>
+ *     <li>{@code long[] hash(input...)} will allocate and return an array containing the results.
  *     </li>
- *     <li>For methods accepting single primitive values, byte sequence is how this primitive
- *     would be put into memory with {@link ByteOrder#nativeOrder() native} byte order, or
- *     equivalently, {@code hashXxx(primitive)} has always the same result as {@code
- *     hashXxxs(new xxx[] {primitive})}, where "xxx" is any Java primitive type name.</li>
- *     <li>For {@link #hash(Object, Access, long, long)} method byte sequence abstraction
- *     is defined by the given {@link Access} strategy to the given object.</li>
  * </ul>
  *
- * <p>Tuple hash function implementation could either produce equal results for equal input on platforms
- * with different {@link ByteOrder}, favoring one byte order in terms of performance, or different
- * results, but performing equally good. This choice should be explicitly documented for all
- * {@code LongTupleHashFunction} implementations.
+ * <b>Warning:</b> Allocations <strong>cannot</strong> be totally avoid to exchange a more than
+ * 64-bit result since there is no value type in java yet. For the first form of a hash method, a
+ * single allocation occurs only at the begining of some runtime scope, so it could be called
+ * <strong>Almost-Zero-Allocation-Hashing</strong>.
  *
- * Each hash api have two forms:
- * <ul>
- *     <li> {code void hash(input..., long[] result)} will put the hash result in array {@code result}
- *     <li> {code long[] hash(input...)} will alloc and return an array container the results
- * </ul>
- * ${@code newResultArray()} api should always be used to create resuable result arrays. And a hash
- * implementation can omit checking the length of result arrays for better performance.
+ * <b>Warning:</b> The second form <strong>always performs exactly one allocation</strong> for the
+ * result array in each invocation, that is <strong>One-Allocation-Hashing</strong>. So prefer the
+ * first form as much as possible.
  *
  * <h3>Subclassing</h3>
- * To implement a specific hash function algorithm resulting more than 64 bits results,
- * this class should be subclassed. Only methods with resued result array that accept single primitives,
- * {@link #hashVoid(long[])} and {@link #hash(Object, Access, long, long, long[])} should be implemented;
- * other have default implementations which in the end delegate to
+ * To implement a specific hash function algorithm resulting more than 64 bits results, this class
+ * should be subclassed. Only methods with resued result array that accept single primitives,
+ * {@link #hashVoid(long[])} and {@link #hash(Object, Access, long, long, long[])} should be
+ * implemented; other have default implementations which in the end delegate to
  * {@link #hash(Object, Access, long, long, long[])} abstract method.
  *
- * The {@code #bitsLength()} method should also be implemented, returning the actual bits in the result
- * array. The bits length should be greater than 64, otherwise just using the {@link #LongHashFunction}
- * interface. And the length should also be a positive multiple of 8.
+ * The {@link #bitsLength} method should also be implemented, returning the actual number of bits in
+ * the result array. The bits length should be greater than 64, otherwise just use the
+ * {@link LongHashFunction} interface. And the length should also be a positive multiple of 8.
  *
- * <p>Notes about how exactly methods with default implementations are implemented in doc comments
- * are given for information and could be changed at any moment. However, it could hardly cause
- * any issues with subclassing, except probably little performance degradation. Methods documented
- * as "shortcuts" could either delegate to the referenced method or delegate directly to the method
- * to which the referenced method delegates.
- *
- *<p>{@code LongTupleHashFunction} implementations shouldn't assume that {@code Access} strategies
- * do defensive checks, and access only bytes within the requested range.
+ * @see LongHashFunction
+ * for additional information about subclassing andd access.
  */
 @ParametersAreNonnullByDefault
 public abstract class LongTupleHashFunction implements Serializable {
@@ -107,12 +95,12 @@ public abstract class LongTupleHashFunction implements Serializable {
     //
 
     /**
-     * Returns the number of bits in a result array; a positive multiple of 8.
+     * Returns the actual number of bits in a result array; a positive multiple of 8.
      */
     public abstract int bitsLength();
 
     /**
-     * Returns a result array
+     * Returns a new-allocated result array.
      */
     @NotNull
     public long[] newResultArray() {
@@ -120,16 +108,27 @@ public abstract class LongTupleHashFunction implements Serializable {
     }
 
     /**
-     * Returns the hash code for the given {@code long} value; this method is consistent with
-     * {@code LongTupleHashFunction} methods that accept sequences of bytes, assuming the {@code input}
-     * value is interpreted in {@linkplain ByteOrder#nativeOrder() native} byte order. For example,
-     * the result of {@code hashLong(v, result)} call is identical to the result of
+     * Computes the hash code for the given {@code long} value, and store the results in the
+     * {@code result} array; this method is consistent with {@code LongTupleHashFunction} methods
+     * that accept sequences of bytes, assuming the {@code input} value is interpreted in
+     * {@linkplain ByteOrder#nativeOrder() native} byte order. For example, the result of
+     * {@code hashLong(v, result)} call is identical to the result of
      * {@code hashLongs(new long[] {v}, result)} call for any {@code long} value.
+     *
+     * The {@code result} array should be always created by {@link #newResultArray} method.
+     * When storing, the {@code result[0 .. newResultArray().length-1]} will be accessed,
+     * the rest elements of the array will not be touched when
+     * {@code result.length > newResultArray().length]}.
+     *
+     * @throws NullPointerException if {@code result == null}
+     * @throws IndexOutOfBoundsException if {@code result.length < newResultArray().length}
      */
     public abstract void hashLong(long input, long[] result);
 
     /**
-     * See {@link #hashLong(long, long[])}
+     * @see #hashLong(long, long[])
+     *
+     * The result array will be allocated on the fly, and no exceptions will be thrown.
      */
     @NotNull
     public long[] hashLong(final long input) {
@@ -139,16 +138,27 @@ public abstract class LongTupleHashFunction implements Serializable {
     }
 
     /**
-     * Returns the hash code for the given {@code int} value; this method is consistent with
-     * {@code LongTupleHashFunction} methods that accept sequences of bytes, assuming the {@code input}
-     * value is interpreted in {@linkplain ByteOrder#nativeOrder() native} byte order. For example,
-     * the result of {@code hashInt(v, result)} call is identical to the result of
-     * {@code hashInts(new int[] {v}, result)} call for any {@code int} value.
+     * Computes the hash code for the given {@code int} value, and store the results in the
+     * {@code result} array; this method is consistent with {@code LongTupleHashFunction} methods
+     * that accept sequences of bytes, assuming the {@code input} value is interpreted in
+     * {@linkplain ByteOrder#nativeOrder() native} byte order. For example, the result of
+     * {@code hashInt(v, result)} call is identical to the result of
+     * {@code hashInts(new long[] {v}, result)} call for any {@code int} value.
+     *
+     * The {@code result} array should be always created by {@link #newResultArray} method.
+     * When storing, the {@code result[0 .. newResultArray().length-1]} will be accessed,
+     * the rest elements of the array will not be touched when
+     * {@code result.length > newResultArray().length]}.
+     *
+     * @throws NullPointerException if {@code result == null}
+     * @throws IndexOutOfBoundsException if {@code result.length < newResultArray().length}
      */
     public abstract void hashInt(int input, long[] result);
 
     /**
-     * See {@link #hashInt(int, long[])}
+     * @see #hashInt(int, long[])
+     *
+     * The result array will be allocated on the fly, and no exceptions will be thrown.
      */
     @NotNull
     public long[] hashInt(final int input) {
@@ -158,18 +168,27 @@ public abstract class LongTupleHashFunction implements Serializable {
     }
 
     /**
-     * Returns the hash code for the given {@code short} value; this method is consistent with
-     * {@code LongTupleHashFunction} methods that accept sequences of bytes, assuming the {@code input}
-     * value is interpreted in {@linkplain ByteOrder#nativeOrder() native} byte order. For example,
-     * the result of {@code hashShort(v, result)} call is identical to the result of
-     * {@code hashShorts(new short[] {v}, result)} call for any {@code short} value.
-     * As a consequence, {@code hashShort(v, result)} call produce always the same result as {@code
-     * hashChar((char) v, result)}.
+     * Computes the hash code for the given {@code short} value, and store the results in the
+     * {@code result} array; this method is consistent with {@code LongTupleHashFunction} methods
+     * that accept sequences of bytes, assuming the {@code input} value is interpreted in
+     * {@linkplain ByteOrder#nativeOrder() native} byte order. For example, the result of
+     * {@code hashShort(v, result)} call is identical to the result of
+     * {@code hashShorts(new long[] {v}, result)} call for any {@code short} value.
+     *
+     * The {@code result} array should be always created by {@link #newResultArray} method.
+     * When storing, the {@code result[0 .. newResultArray().length-1]} will be accessed,
+     * the rest elements of the array will not be touched when
+     * {@code result.length > newResultArray().length]}.
+     *
+     * @throws NullPointerException if {@code result == null}
+     * @throws IndexOutOfBoundsException if {@code result.length < newResultArray().length}
      */
     public abstract void hashShort(short input, long[] result);
 
     /**
-     * See {@link #hashShort(short, long[])}
+     * @see #hashShort(short, long[])
+     *
+     * The result array will be allocated on the fly, and no exceptions will be thrown.
      */
     @NotNull
     public long[] hashShort(final short input) {
@@ -179,6 +198,7 @@ public abstract class LongTupleHashFunction implements Serializable {
     }
 
     /**
+     * TODO
      * Returns the hash code for the given {@code char} value; this method is consistent with
      * {@code LongTupleHashFunction} methods that accept sequences of bytes, assuming the {@code input}
      * value is interpreted in {@linkplain ByteOrder#nativeOrder() native} byte order. For example,
@@ -190,7 +210,9 @@ public abstract class LongTupleHashFunction implements Serializable {
     public abstract void hashChar(char input, long[] result);
 
     /**
-     * See {@link #hashChar(char, long[])}
+     * @see #hashChar(char, long[])
+     *
+     * The result array will be allocated on the fly, and no exceptions will be thrown.
      */
     @NotNull
     public long[] hashChar(final char input) {
@@ -208,7 +230,9 @@ public abstract class LongTupleHashFunction implements Serializable {
     public abstract void hashByte(byte input, long[] result);
 
     /**
-     * See {@link #hashByte(byte, long[])}
+     * @see #hashByte(byte, long[])
+     *
+     * The result array will be allocated on the fly, and no exceptions will be thrown.
      */
     @NotNull
     public long[] hashByte(final byte input) {
@@ -224,7 +248,9 @@ public abstract class LongTupleHashFunction implements Serializable {
     public abstract void hashVoid(long[] result);
 
     /**
-     * See {@link #hashVoid(long[])}
+     * @see #hashVoid(long[])
+     *
+     * The result array will be allocated on the fly, and no exceptions will be thrown.
      */
     @NotNull
     public long[] hashVoid() {
@@ -248,16 +274,20 @@ public abstract class LongTupleHashFunction implements Serializable {
      * @param off offset to the first byte of the subsequence to hash
      * @param len length of the subsequence to hash
      * @param result the container array for putting the hash results,
-     *               should be alloced by ${@code #newResultArray()}
+     *               should be alloced by {@link #newResultArray}
      * @param <T> the type of the input
      */
-    public abstract <T> void hash(@Nullable T input, Access<T> access, long off, long len, long[] result);
+    public abstract <T> void hash(@Nullable T input, Access<T> access,
+                                  long off, long len, long[] result);
 
     /**
-     * See {@link #hash(T, Access, long, long, long[])}
+     * @see #hash(T, Access, long, long, long[])
+     *
+     * The result array will be allocated on the fly, and no exceptions will be thrown.
      */
     @NotNull
-    public <T> long[] hash(@Nullable final T input, final Access<T> access, final long off, final long len) {
+    public <T> long[] hash(@Nullable final T input, final Access<T> access,
+                           final long off, final long len) {
         final long[] result = newResultArray();
         hash(input, access, off, len, result);
         return result;
@@ -273,7 +303,9 @@ public abstract class LongTupleHashFunction implements Serializable {
     }
 
     /**
-     * See {@link #hashBoolean(boolean, long[])}
+     * @see #hashBoolean(boolean, long[])
+     *
+     * The result array will be allocated on the fly, and no exceptions will be thrown.
      */
     @NotNull
     public long[] hashBoolean(final boolean input) {
@@ -290,7 +322,9 @@ public abstract class LongTupleHashFunction implements Serializable {
     }
 
     /**
-     * See {@link #hashBooleans(boolean[], long[])}
+     * @see #hashBooleans(boolean[], long[])
+     *
+     * The result array will be allocated on the fly, and no exceptions will be thrown.
      */
     @NotNull
     public long[] hashBooleans(final boolean[] input) {
@@ -309,17 +343,20 @@ public abstract class LongTupleHashFunction implements Serializable {
      * @param off index of the first {@code boolean} in the subsequence to hash
      * @param len length of the subsequence to hash
      * @param result the container array for putting the hash results,
-     *               should be alloced by ${@code #newResultArray()}
+     *               should be alloced by {@link #newResultArray}
      * @throws IndexOutOfBoundsException if {@code off < 0} or {@code off + len > input.length}
      * or {@code len < 0}
      */
-    public void hashBooleans(final boolean[] input, final int off, final int len, final long[] result) {
+    public void hashBooleans(final boolean[] input,
+                             final int off, final int len, final long[] result) {
         checkArrayOffs(input.length, off, len);
         unsafeHash(this, input, BOOLEAN_BASE + off, len, result);
     }
 
     /**
-     * See {@link #hashBooleans(boolean[], int, int, long[])}
+     * @see #hashBooleans(boolean[], int, int, long[])
+     *
+     * The result array will be allocated on the fly, and no exceptions will be thrown.
      */
     @NotNull
     public long[] hashBooleans(final boolean[] input, final int off, final int len) {
@@ -337,7 +374,9 @@ public abstract class LongTupleHashFunction implements Serializable {
     }
 
     /**
-     * See {@link #hashBytes(byte[], long[])}
+     * @see #hashBytes(byte[], long[])
+     *
+     * The result array will be allocated on the fly, and no exceptions will be thrown.
      */
     @NotNull
     public long[] hashBytes(final byte[] input) {
@@ -356,7 +395,7 @@ public abstract class LongTupleHashFunction implements Serializable {
      * @param off index of the first {@code byte} in the subsequence to hash
      * @param len length of the subsequence to hash
      * @param result the container array for putting the hash results,
-     *               should be alloced by ${@code #newResultArray()}
+     *               should be alloced by {@link #newResultArray}
      * @throws IndexOutOfBoundsException if {@code off < 0} or {@code off + len > input.length}
      * or {@code len < 0}
      */
@@ -366,7 +405,9 @@ public abstract class LongTupleHashFunction implements Serializable {
     }
 
     /**
-     * See {@link #hashBytes(byte[], int, int, long[])}
+     * @see #hashBytes(byte[], int, int, long[])
+     *
+     * The result array will be allocated on the fly, and no exceptions will be thrown.
      */
     @NotNull
     public long[] hashBytes(final byte[] input, final int off, final int len) {
@@ -385,7 +426,9 @@ public abstract class LongTupleHashFunction implements Serializable {
     }
 
     /**
-     * See {@link #hashBytes(ByteBuffer, long[])}
+     * @see #hashBytes(ByteBuffer, long[])
+     *
+     * The result array will be allocated on the fly, and no exceptions will be thrown.
      */
     @NotNull
     public long[] hashBytes(final ByteBuffer input) {
@@ -407,17 +450,20 @@ public abstract class LongTupleHashFunction implements Serializable {
      * @param off index of the first {@code byte} in the subsequence to hash
      * @param len length of the subsequence to hash
      * @param result the container array for putting the hash results,
-     *               should be alloced by ${@code #newResultArray()}
+     *               should be alloced by {@link #newResultArray}
      * @throws IndexOutOfBoundsException if {@code off < 0} or {@code off + len > input.capacity()}
      * or {@code len < 0}
      */
-    public void hashBytes(final ByteBuffer input, final int off, final int len, final long[] result) {
+    public void hashBytes(final ByteBuffer input,
+                          final int off, final int len, final long[] result) {
         checkArrayOffs(input.capacity(), off, len);
         hashByteBuffer(this, input, off, len, result);
     }
 
     /**
-     * See {@link #hashBytes(ByteBuffer, int, int, long[])}
+     * @see #hashBytes(ByteBuffer, int, int, long[])
+     *
+     * The result array will be allocated on the fly, and no exceptions will be thrown.
      */
     @NotNull
     public long[] hashBytes(final ByteBuffer input, final int off, final int len) {
@@ -436,14 +482,16 @@ public abstract class LongTupleHashFunction implements Serializable {
      * @param address the address of the first byte to hash
      * @param len length of the byte sequence to hash
      * @param result the container array for putting the hash results,
-     *               should be alloced by ${@code #newResultArray()}
+     *               should be alloced by {@link #newResultArray}
      */
     public void hashMemory(final long address, final long len, final long[] result) {
         unsafeHash(this, null, address, len, result);
     }
 
     /**
-     * See {@link #hashMemory(long, long, long[])}
+     * @see #hashMemory(long, long, long[])
+     *
+     * The result array will be allocated on the fly, and no exceptions will be thrown.
      */
     @NotNull
     public long[] hashMemory(final long address, final long len) {
@@ -460,7 +508,9 @@ public abstract class LongTupleHashFunction implements Serializable {
     }
 
     /**
-     * See {@link #hashChars(char[], long[])}
+     * @see #hashChars(char[], long[])
+     *
+     * The result array will be allocated on the fly, and no exceptions will be thrown.
      */
     @NotNull
     public long[] hashChars(final char[] input) {
@@ -481,7 +531,7 @@ public abstract class LongTupleHashFunction implements Serializable {
      * @param len length of the subsequence to hash, in chars (i. e. the length of the bytes
      *            sequence to hash is {@code len * 2L})
      * @param result the container array for putting the hash results,
-     *               should be alloced by ${@code #newResultArray()}
+     *               should be alloced by {@link #newResultArray}
      * @throws IndexOutOfBoundsException if {@code off < 0} or {@code off + len > input.length}
      * or {@code len < 0}
      */
@@ -491,7 +541,9 @@ public abstract class LongTupleHashFunction implements Serializable {
     }
 
     /**
-     * See {@link #hashChars(char[], int, int, long[])}
+     * @see #hashChars(char[], int, int, long[])
+     *
+     * The result array will be allocated on the fly, and no exceptions will be thrown.
      */
     @NotNull
     public long[] hashChars(final char[] input, final int off, final int len) {
@@ -509,7 +561,9 @@ public abstract class LongTupleHashFunction implements Serializable {
     }
 
     /**
-     * See {@link #hashChars(String, long[])}
+     * @see #hashChars(String, long[])
+     *
+     * The result array will be allocated on the fly, and no exceptions will be thrown.
      */
     @NotNull
     public long[] hashChars(final String input) {
@@ -530,7 +584,7 @@ public abstract class LongTupleHashFunction implements Serializable {
      * @param len length of the subsequence to hash, in chars (i. e. the length of the bytes
      *            sequence to hash is {@code len * 2L})
      * @param result the container array for putting the hash results,
-     *               should be alloced by ${@code #newResultArray()}
+     *               should be alloced by {@link #newResultArray}
      * @throws IndexOutOfBoundsException if {@code off < 0} or {@code off + len > input.length()}
      * or {@code len < 0}
      */
@@ -540,7 +594,9 @@ public abstract class LongTupleHashFunction implements Serializable {
     }
 
     /**
-     * See {@link #hashChars(String, int, int long[])}
+     * @see #hashChars(String, int, int long[])
+     *
+     * The result array will be allocated on the fly, and no exceptions will be thrown.
      */
     @NotNull
     public long[] hashChars(final String input, final int off, final int len) {
@@ -558,7 +614,9 @@ public abstract class LongTupleHashFunction implements Serializable {
     }
 
     /**
-     * See {@link #hashChars(T, long[])}
+     * @see #hashChars(T, long[])
+     *
+     * The result array will be allocated on the fly, and no exceptions will be thrown.
      */
     @NotNull
     public <T extends CharSequence> long[] hashChars(final T input) {
@@ -579,18 +637,21 @@ public abstract class LongTupleHashFunction implements Serializable {
      * @param len length of the subsequence to hash, in chars (i. e. the length of the bytes
      *            sequence to hash is {@code len * 2L})
      * @param result the container array for putting the hash results,
-     *               should be alloced by ${@code #newResultArray()}
+     *               should be alloced by {@link #newResultArray}
      * @param <T> the type of the input which extends CharSequence
      * @throws IndexOutOfBoundsException if {@code off < 0} or {@code off + len > input.length()}
      * or {@code len < 0}
      */
-    public <T extends CharSequence> void hashChars(final T input, final int off, final int len, final long[] result) {
+    public <T extends CharSequence> void hashChars(final T input, final int off, final int len,
+                                                   final long[] result) {
         checkArrayOffs(input.length(), off, len);
         hashNativeChars(this, input, off, len, result);
     }
 
     /**
-     * See {@link #hashChars(T, int, int, long[])}
+     * @see #hashChars(T, int, int, long[])
+     *
+     * The result array will be allocated on the fly, and no exceptions will be thrown.
      */
     @NotNull
     public <T extends CharSequence> long[] hashChars(final T input, final int off, final int len) {
@@ -608,7 +669,9 @@ public abstract class LongTupleHashFunction implements Serializable {
     }
 
     /**
-     * See {@link #hashShorts(short[], long[])}
+     * @see #hashShorts(short[], long[])
+     *
+     * The result array will be allocated on the fly, and no exceptions will be thrown.
      */
     @NotNull
     public long[] hashShorts(final short[] input) {
@@ -629,7 +692,7 @@ public abstract class LongTupleHashFunction implements Serializable {
      * @param len length of the subsequence to hash, in shorts (i. e. the length of the bytes
      *            sequence to hash is {@code len * 2L})
      * @param result the container array for putting the hash results,
-     *               should be alloced by ${@code #newResultArray()}
+     *               should be alloced by {@link #newResultArray}
      * @throws IndexOutOfBoundsException if {@code off < 0} or {@code off + len > input.length}
      * or {@code len < 0}
      */
@@ -639,7 +702,9 @@ public abstract class LongTupleHashFunction implements Serializable {
     }
 
     /**
-     * See {@link #hashShorts(short[], int, int, long[])}
+     * @see #hashShorts(short[], int, int, long[])
+     *
+     * The result array will be allocated on the fly, and no exceptions will be thrown.
      */
     @NotNull
     public long[] hashShorts(final short[] input, final int off, final int len) {
@@ -657,7 +722,9 @@ public abstract class LongTupleHashFunction implements Serializable {
     }
 
     /**
-     * See {@link #hashInts(int[], long[])}
+     * @see #hashInts(int[], long[])
+     *
+     * The result array will be allocated on the fly, and no exceptions will be thrown.
      */
     @NotNull
     public long[] hashInts(final int[] input) {
@@ -678,7 +745,7 @@ public abstract class LongTupleHashFunction implements Serializable {
      * @param len length of the subsequence to hash, in ints (i. e. the length of the bytes
      *            sequence to hash is {@code len * 4L})
      * @param result the container array for putting the hash results,
-     *               should be alloced by ${@code #newResultArray()}
+     *               should be alloced by {@link #newResultArray}
      * @throws IndexOutOfBoundsException if {@code off < 0} or {@code off + len > input.length}
      * or {@code len < 0}
      */
@@ -688,7 +755,9 @@ public abstract class LongTupleHashFunction implements Serializable {
     }
 
     /**
-     * See {@link #hashInts(int[], int, int, long[])}
+     * @see #hashInts(int[], int, int, long[])
+     *
+     * The result array will be allocated on the fly, and no exceptions will be thrown.
      */
     @NotNull
     public long[] hashInts(final int[] input, final int off, final int len) {
@@ -706,7 +775,9 @@ public abstract class LongTupleHashFunction implements Serializable {
     }
 
     /**
-     * See {@link #hashLongs(long[], long[])}
+     * @see #hashLongs(long[], long[])
+     *
+     * The result array will be allocated on the fly, and no exceptions will be thrown.
      */
     @NotNull
     public long[] hashLongs(final long[] input) {
@@ -727,7 +798,7 @@ public abstract class LongTupleHashFunction implements Serializable {
      * @param len length of the subsequence to hash, in longs (i. e. the length of the bytes
      *            sequence to hash is {@code len * 8L})
      * @param result the container array for putting the hash results,
-     *               should be alloced by ${@code #newResultArray()}
+     *               should be alloced by {@link #newResultArray}
      * @throws IndexOutOfBoundsException if {@code off < 0} or {@code off + len > input.length}
      * or {@code len < 0}
      */
@@ -737,7 +808,9 @@ public abstract class LongTupleHashFunction implements Serializable {
     }
 
     /**
-     * See {@link #hashLongs(long[], int, int, long[])}
+     * @see #hashLongs(long[], int, int, long[])
+     *
+     * The result array will be allocated on the fly, and no exceptions will be thrown.
      */
     @NotNull
     public long[] hashLongs(final long[] input, final int off, final int len) {
@@ -757,12 +830,12 @@ public abstract class LongTupleHashFunction implements Serializable {
     private static final Access<ByteBuffer> BYTE_BUF_ACCESS = ByteBufferAccess.INSTANCE;
 
     private static void unsafeHash(final LongTupleHashFunction f, @Nullable final Object input,
-                    final long off, final long len, final long[] result) {
+                                   final long off, final long len, final long[] result) {
         f.hash(input, OBJECT_ACCESS, off, len, result);
     }
 
     private static void hashByteBuffer(final LongTupleHashFunction f, final ByteBuffer input,
-                    final int off, final int len, final long[] result) {
+                                       final int off, final int len, final long[] result) {
         if (input.hasArray()) {
             unsafeHash(f, input.array(), BYTE_BASE + input.arrayOffset() + off, len, result);
         } else if (input instanceof DirectBuffer) {
@@ -773,7 +846,7 @@ public abstract class LongTupleHashFunction implements Serializable {
     }
 
     static void hashNativeChars(final LongTupleHashFunction f, final CharSequence input,
-                    final int off, final int len, final long[] result) {
+                                final int off, final int len, final long[] result) {
         f.hash(input, CHAR_SEQ_ACCESS, off * 2L, len * 2L, result);
     }
 }

--- a/src/main/java/net/openhft/hashing/LongTupleHashFunction.java
+++ b/src/main/java/net/openhft/hashing/LongTupleHashFunction.java
@@ -18,25 +18,28 @@ import static net.openhft.hashing.Util.*;
  * {@code long[]} from any byte sequences. See {@link LongHashFunction} for the definition of byte
  * sequence semantics and {@link ByteOrder} requirements for implementations.
  *
- * Every {@link LongHashFunction} hash method has two corresponding ones in this class for different
+ * <p>Every {@link LongHashFunction} hash method has two corresponding ones in this class for different
  * allocation strategies:
  * <ul>
- *     <li>{@code void hash(input..., long[] result)} will store the hash results in array
- *     {@code result[0 .. newResultArray().length-1]}, and throws exceptions when
- *     {@code result == null} or the length of the array is less than
+ *     <li><strong>{@code void hash(input..., long[] result)}</strong>
+ *
+ *     <p>will store the hash results in array {@code result[0 .. newResultArray().length-1]}, and
+ *     throws exceptions when {@code result == null} or the length of the array is less than
  *     {@code newResultArray().length}. {@link #newResultArray} method should always be used to
- *     create resuable result arrays to avoid exceptions. See {@link #hashLong(long, long[])}.</li>
- *     <li>{@code long[] hash(input...)} will allocate and return an array containing the results.
- *     </li>
+ *     create resuable result arrays to avoid exceptions. See {@link #hashLong(long, long[])}.
+ *
+ *     <p><b>Warning:</b> A single allocation occurs only at the begining of some runtime scope, so
+ *     it could be called <strong>Almost-Zero-Allocation-Hashing</strong>.</li>
+ *
+ *     <li><b>{@code long[] hash(input...)}</b>
+ *
+ *     <p>will allocate and return an array containing the results.
+ *
+ *     <p><b>Warning:</b> Methods with this form
+ *     <strong>always perform exactly one allocation</strong> for the result array in each
+ *     invocation, that is <strong>One-Allocation-Hashing</strong>. So prefer the first form as much
+ *     as possible.</li>
  * </ul>
- *
- * <p><b>Warning:</b> For the first form of a hash method, a single allocation occurs only at the
- * begining of some runtime scope, so it could be called
- * <strong>Almost-Zero-Allocation-Hashing</strong>.
- *
- * <p><b>Warning:</b> The second form <strong>always performs exactly one allocation</strong> for
- * the result array in each invocation, that is <strong>One-Allocation-Hashing</strong>. So prefer
- * the first form as much as possible.
  *
  * <h3>Subclassing</h3>
  * To implement a specific hash function algorithm resulting more than 64 bits results, this class
@@ -45,12 +48,13 @@ import static net.openhft.hashing.Util.*;
  * implemented; other have default implementations which in the end delegate to
  * {@link #hash(Object, Access, long, long, long[])} abstract method.
  *
- * The {@link #bitsLength} method should also be implemented, returning the actual number of bits in
- * the result array. The bits length should be greater than 64, otherwise just use the
+ * <p>The {@link #bitsLength} method should also be implemented, returning the actual number of bits
+ * in the result array. The bits length must be greater than 64, otherwise just use the
  * {@link LongHashFunction} interface. And the length should also be a positive multiple of 8.
  *
- * @see LongHashFunction
- * for additional information about subclassing andd access.
+ * <p>Also see {@link LongHashFunction} for additional information about subclassing andd access.
+ *
+ * @see LongHashFunction LongHashFunction
  */
 @ParametersAreNonnullByDefault
 public abstract class LongTupleHashFunction implements Serializable {
@@ -103,8 +107,8 @@ public abstract class LongTupleHashFunction implements Serializable {
     /**
      * Returns a new-allocated result array.
      *
-     * If the ${@code bitsLength()} returns non-multiple of 64, the implementation of this method
-     * should round-up the length to a multiple of 64 for allocating the {@code long} array.
+     * If {@code bitsLength()} returns non-multiple of 64, the implementation of this method should
+     * round-up the length to a multiple of 64 for allocating the {@code long} array.
      */
     @NotNull
     public long[] newResultArray() {
@@ -119,9 +123,9 @@ public abstract class LongTupleHashFunction implements Serializable {
      * {@code hashLong(v, result)} call is identical to the result of
      * {@code hashLongs(new long[] {v}, result)} call for any {@code long} value.
      *
-     * The {@code result} array should be always created by {@link #newResultArray} method.
-     * When storing, the {@code result[0 .. newResultArray().length-1]} will be accessed,
-     * the rest elements of the array will not be touched when
+     * <p>The {@code result} array should be always created by {@link #newResultArray} method. When
+     * storing, the {@code result[0 .. newResultArray().length-1]} will be accessed, the rest
+     * elements of the array will not be touched when
      * {@code result.length > newResultArray().length]}.
      *
      * @throws NullPointerException if {@code result == null}
@@ -130,9 +134,9 @@ public abstract class LongTupleHashFunction implements Serializable {
     public abstract void hashLong(long input, long[] result);
 
     /**
-     * @see #hashLong(long, long[])
-     *
      * The result array is allocated on the fly, and no exceptions will be thrown.
+     *
+     * @see #hashLong(long, long[])
      */
     @NotNull
     public long[] hashLong(final long input) {
@@ -149,9 +153,9 @@ public abstract class LongTupleHashFunction implements Serializable {
      * {@code hashInt(v, result)} call is identical to the result of
      * {@code hashInts(new int[] {v}, result)} call for any {@code int} value.
      *
-     * The {@code result} array should be always created by {@link #newResultArray} method.
-     * When storing, the {@code result[0 .. newResultArray().length-1]} will be accessed,
-     * the rest elements of the array will not be touched when
+     * <p>The {@code result} array should be always created by {@link #newResultArray} method. When
+     * storing, the {@code result[0 .. newResultArray().length-1]} will be accessed, the rest
+     * elements of the array will not be touched when
      * {@code result.length > newResultArray().length]}.
      *
      * @throws NullPointerException if {@code result == null}
@@ -160,9 +164,9 @@ public abstract class LongTupleHashFunction implements Serializable {
     public abstract void hashInt(int input, long[] result);
 
     /**
-     * @see #hashInt(int, long[])
-     *
      * The result array is allocated on the fly, and no exceptions will be thrown.
+     *
+     * @see #hashInt(int, long[])
      */
     @NotNull
     public long[] hashInt(final int input) {
@@ -179,9 +183,9 @@ public abstract class LongTupleHashFunction implements Serializable {
      * {@code hashShort(v, result)} call is identical to the result of
      * {@code hashShorts(new short[] {v}, result)} call for any {@code short} value.
      *
-     * The {@code result} array should be always created by {@link #newResultArray} method.
-     * When storing, the {@code result[0 .. newResultArray().length-1]} will be accessed,
-     * the rest elements of the array will not be touched when
+     * <p>The {@code result} array should be always created by {@link #newResultArray} method. When
+     * storing, the {@code result[0 .. newResultArray().length-1]} will be accessed, the rest
+     * elements of the array will not be touched when
      * {@code result.length > newResultArray().length]}.
      *
      * @throws NullPointerException if {@code result == null}
@@ -190,9 +194,9 @@ public abstract class LongTupleHashFunction implements Serializable {
     public abstract void hashShort(short input, long[] result);
 
     /**
-     * @see #hashShort(short, long[])
-     *
      * The result array is allocated on the fly, and no exceptions will be thrown.
+     *
+     * @see #hashShort(short, long[])
      */
     @NotNull
     public long[] hashShort(final short input) {
@@ -207,11 +211,11 @@ public abstract class LongTupleHashFunction implements Serializable {
      * that accept sequences of bytes, assuming the {@code input} value is interpreted in
      * {@linkplain ByteOrder#nativeOrder() native} byte order. For example, the result of
      * {@code hashChar(v, result)} call is identical to the result of
-     * {@code hashChars(new char[] {v}, result)} call for any {@code short} value.
+     * {@code hashChars(new char[] {v}, result)} call for any {@code char} value.
      *
-     * The {@code result} array should be always created by {@link #newResultArray} method.
-     * When storing, the {@code result[0 .. newResultArray().length-1]} will be accessed,
-     * the rest elements of the array will not be touched when
+     * <p>The {@code result} array should be always created by {@link #newResultArray} method. When
+     * storing, the {@code result[0 .. newResultArray().length-1]} will be accessed, the rest
+     * elements of the array will not be touched when
      * {@code result.length > newResultArray().length]}.
      *
      * @throws NullPointerException if {@code result == null}
@@ -220,9 +224,9 @@ public abstract class LongTupleHashFunction implements Serializable {
     public abstract void hashChar(char input, long[] result);
 
     /**
-     * @see #hashChar(char, long[])
-     *
      * The result array is allocated on the fly, and no exceptions will be thrown.
+     *
+     * @see #hashChar(char, long[])
      */
     @NotNull
     public long[] hashChar(final char input) {
@@ -234,14 +238,13 @@ public abstract class LongTupleHashFunction implements Serializable {
     /**
      * Computes the hash code for the given {@code byte} value, and store the results in the
      * {@code result} array; this method is consistent with {@code LongTupleHashFunction} methods
-     * that accept sequences of bytes, assuming the {@code input} value is interpreted in
-     * {@linkplain ByteOrder#nativeOrder() native} byte order. For example, the result of
-     * {@code hashByte(v, result)} call is identical to the result of
+     * that accept sequences of bytes, assuming the {@code input} value is the first and only byte.
+     * For example, the result of {@code hashByte(v, result)} call is identical to the result of
      * {@code hashBytes(new byte[] {v}, result)} call for any {@code byte} value.
      *
-     * The {@code result} array should be always created by {@link #newResultArray} method.
-     * When storing, the {@code result[0 .. newResultArray().length-1]} will be accessed,
-     * the rest elements of the array will not be touched when
+     * <p>The {@code result} array should be always created by {@link #newResultArray} method. When
+     * storing, the {@code result[0 .. newResultArray().length-1]} will be accessed, the rest
+     * elements of the array will not be touched when
      * {@code result.length > newResultArray().length]}.
      *
      * @throws NullPointerException if {@code result == null}
@@ -250,9 +253,9 @@ public abstract class LongTupleHashFunction implements Serializable {
     public abstract void hashByte(byte input, long[] result);
 
     /**
-     * @see #hashByte(byte, long[])
-     *
      * The result array is allocated on the fly, and no exceptions will be thrown.
+     *
+     * @see #hashByte(byte, long[])
      */
     @NotNull
     public long[] hashByte(final byte input) {
@@ -266,9 +269,9 @@ public abstract class LongTupleHashFunction implements Serializable {
      * the {@code result} array. For example, the result of {@code hashVoid(result)} call is
      * identical to the result of {@code hashBytes(new byte[0], result)} call.
      *
-     * The {@code result} array should be always created by {@link #newResultArray} method.
-     * When storing, the {@code result[0 .. newResultArray().length-1]} will be accessed,
-     * the rest elements of the array will not be touched when
+     * <p>The {@code result} array should be always created by {@link #newResultArray} method. When
+     * storing, the {@code result[0 .. newResultArray().length-1]} will be accessed, the rest
+     * elements of the array will not be touched when
      * {@code result.length > newResultArray().length]}.
      *
      * @throws NullPointerException if {@code result == null}
@@ -277,9 +280,9 @@ public abstract class LongTupleHashFunction implements Serializable {
     public abstract void hashVoid(long[] result);
 
     /**
-     * @see #hashVoid(long[])
-     *
      * The result array is allocated on the fly, and no exceptions will be thrown.
+     *
+     * @see #hashVoid(long[])
      */
     @NotNull
     public long[] hashVoid() {
@@ -289,31 +292,37 @@ public abstract class LongTupleHashFunction implements Serializable {
     }
 
     /**
-     * TODO
-     * Returns the hash code for {@code len} continuous bytes of the given {@code input} object,
-     * starting from the given offset. The abstraction of input as ordered byte sequence and
-     * "offset within the input" is defined by the given {@code access} strategy.
+     * Computes the hash code for the given {@code input} object starting from the given offset, and
+     * store the results in the {@code result} array. The abstraction of input as ordered byte
+     * sequence and "offset within the input" is defined by the given {@code access} strategy.
      *
-     * <p>This method doesn't promise to throw a {@code RuntimeException} if {@code
-     * [off, off + len - 1]} subsequence exceeds the bounds of the bytes sequence, defined by {@code
-     * access} strategy for the given {@code input}, so use this method with caution.
+     * <p>This method doesn't promise to throw a {@code RuntimeException} if
+     * {@code [off, off + len - 1]} subsequence exceeds the bounds of the bytes sequence, defined by
+     * {@code access} strategy for the given {@code input}, so use this method with caution.
+     *
+     * <p>The {@code result} array should be always created by {@link #newResultArray} method. When
+     * storing, the {@code result[0 .. newResultArray().length-1]} will be accessed, the rest
+     * elements of the array will not be touched when
+     * {@code result.length > newResultArray().length]}.
      *
      * @param input the object to read bytes from
      * @param access access which defines the abstraction of the given input
      *               as ordered byte sequence
      * @param off offset to the first byte of the subsequence to hash
      * @param len length of the subsequence to hash
-     * @param result the container array for putting the hash results,
+     * @param result the container array for storing the hash results,
      *               should be alloced by {@link #newResultArray}
      * @param <T> the type of the input
+     * @throws NullPointerException if {@code result == null}
+     * @throws IllegalArgumentException if {@code result.length < newResultArray().length}
      */
     public abstract <T> void hash(@Nullable T input, Access<T> access,
                                   long off, long len, long[] result);
 
     /**
-     * @see #hash(Object, Access, long, long, long[])
-     *
      * The result array is allocated on the fly, and no exceptions will be thrown.
+     *
+     * @see #hash(Object, Access, long, long, long[])
      */
     @NotNull
     public <T> long[] hash(@Nullable final T input, final Access<T> access,
@@ -324,18 +333,20 @@ public abstract class LongTupleHashFunction implements Serializable {
     }
 
     /**
-     * Shortcut for {@link #hashBooleans(boolean[], long[]) hashBooleans(new boolean[] &#123;input&#125;, result)}.
-     * Note that this is not necessarily equal to {@code hashByte(input ? (byte) 1 : (byte) 0, result)},
-     * because booleans could be stored differently in this JVM.
+     * Shortcut for
+     * {@link #hashBooleans(boolean[], long[]) hashBooleans(new boolean[] &#123;input&#125;, result)}.
+     * Note that this is not necessarily equal to
+     * {@code hashByte(input ? (byte) 1 : (byte) 0, result)}, because booleans could be stored
+     * differently in this JVM.
      */
     public void hashBoolean(final boolean input, final long[] result) {
         hashByte(input ? TRUE_BYTE_VALUE : FALSE_BYTE_VALUE, result);
     }
 
     /**
-     * @see #hashBoolean(boolean, long[])
-     *
      * The result array is allocated on the fly, and no exceptions will be thrown.
+     *
+     * @see #hashBoolean(boolean, long[])
      */
     @NotNull
     public long[] hashBoolean(final boolean input) {
@@ -352,9 +363,9 @@ public abstract class LongTupleHashFunction implements Serializable {
     }
 
     /**
-     * @see #hashBooleans(boolean[], long[])
-     *
      * The result array is allocated on the fly, and no exceptions will be thrown.
+     *
+     * @see #hashBooleans(boolean[], long[])
      */
     @NotNull
     public long[] hashBooleans(final boolean[] input) {
@@ -364,18 +375,26 @@ public abstract class LongTupleHashFunction implements Serializable {
     }
 
     /**
-     * Returns the hash code for the specified subsequence of the given {@code boolean} array.
+     * Computes the hash code for the specified subsequence of the given {@code boolean} array, and
+     * store the results in the {@code result} array.
      *
-     * <p>Default implementation delegates to {@link #hash(Object, Access, long, long, long[])} method
-     * using {@linkplain Access#unsafe() unsafe} {@code Access}.
+     * <p>Default implementation delegates to {@link #hash(Object, Access, long, long, long[])}
+     * method using {@linkplain Access#unsafe() unsafe} {@code Access}.
+     *
+     * <p>The {@code result} array should be always created by {@link #newResultArray} method. When
+     * storing, the {@code result[0 .. newResultArray().length-1]} will be accessed, the rest
+     * elements of the array will not be touched when
+     * {@code result.length > newResultArray().length]}.
      *
      * @param input the array to read data from
      * @param off index of the first {@code boolean} in the subsequence to hash
      * @param len length of the subsequence to hash
-     * @param result the container array for putting the hash results,
+     * @param result the container array for storing the hash results,
      *               should be alloced by {@link #newResultArray}
+     * @throws NullPointerException if {@code result == null}
+     * @throws IllegalArgumentException if {@code result.length < newResultArray().length}
      * @throws IllegalArgumentException if {@code off < 0} or {@code off + len > input.length}
-     * or {@code len < 0}
+     *                                  or {@code len < 0}
      */
     public void hashBooleans(final boolean[] input,
                              final int off, final int len, final long[] result) {
@@ -384,9 +403,9 @@ public abstract class LongTupleHashFunction implements Serializable {
     }
 
     /**
-     * @see #hashBooleans(boolean[], int, int, long[])
+     * The result array is allocated on the fly.
      *
-     * The result array is allocated on the fly, and no exceptions will be thrown.
+     * @see #hashBooleans(boolean[], int, int, long[])
      */
     @NotNull
     public long[] hashBooleans(final boolean[] input, final int off, final int len) {
@@ -404,9 +423,9 @@ public abstract class LongTupleHashFunction implements Serializable {
     }
 
     /**
-     * @see #hashBytes(byte[], long[])
-     *
      * The result array is allocated on the fly, and no exceptions will be thrown.
+     *
+     * @see #hashBytes(byte[], long[])
      */
     @NotNull
     public long[] hashBytes(final byte[] input) {
@@ -416,18 +435,26 @@ public abstract class LongTupleHashFunction implements Serializable {
     }
 
     /**
-     * Returns the hash code for the specified subsequence of the given {@code byte} array.
+     * Computes the hash code for the specified subsequence of the given {@code byte} array, and
+     * store the results in the {@code result} array.
      *
      * <p>Default implementation delegates to {@link #hash(Object, Access, long, long, long[])}
      * method using {@linkplain Access#unsafe() unsafe} {@code Access}.
      *
-     * @param input the array to read bytes from
+     * <p>The {@code result} array should be always created by {@link #newResultArray} method. When
+     * storing, the {@code result[0 .. newResultArray().length-1]} will be accessed, the rest
+     * elements of the array will not be touched when
+     * {@code result.length > newResultArray().length]}.
+     *
+     * @param input the array to read data from
      * @param off index of the first {@code byte} in the subsequence to hash
      * @param len length of the subsequence to hash
-     * @param result the container array for putting the hash results,
+     * @param result the container array for storing the hash results,
      *               should be alloced by {@link #newResultArray}
+     * @throws NullPointerException if {@code result == null}
+     * @throws IllegalArgumentException if {@code result.length < newResultArray().length}
      * @throws IllegalArgumentException if {@code off < 0} or {@code off + len > input.length}
-     * or {@code len < 0}
+     *                                  or {@code len < 0}
      */
     public void hashBytes(final byte[] input, final int off, final int len, final long[] result) {
         checkArrayOffs(input.length, off, len);
@@ -435,9 +462,9 @@ public abstract class LongTupleHashFunction implements Serializable {
     }
 
     /**
-     * @see #hashBytes(byte[], int, int, long[])
+     * The result array is allocated on the fly.
      *
-     * The result array is allocated on the fly, and no exceptions will be thrown.
+     * @see #hashBytes(byte[], int, int, long[])
      */
     @NotNull
     public long[] hashBytes(final byte[] input, final int off, final int len) {
@@ -456,9 +483,9 @@ public abstract class LongTupleHashFunction implements Serializable {
     }
 
     /**
-     * @see #hashBytes(ByteBuffer, long[])
-     *
      * The result array is allocated on the fly, and no exceptions will be thrown.
+     *
+     * @see #hashBytes(ByteBuffer, long[])
      */
     @NotNull
     public long[] hashBytes(final ByteBuffer input) {
@@ -468,21 +495,29 @@ public abstract class LongTupleHashFunction implements Serializable {
     }
 
     /**
-     * Returns the hash code for the specified subsequence of the given {@code ByteBuffer}.
+     * Computes the hash code for the specified subsequence of the given {@code ByteBuffer}, and
+     * store the results in the {@code result} array.
      *
      * <p>This method doesn't alter the state (mark, position, limit or order) of the given
      * {@code ByteBuffer}.
      *
      * <p>Default implementation delegates to {@link #hash(Object, Access, long, long, long[])}
-     * method using {@link Access#toByteBuffer()}.
+     * method using {@linkplain Access#unsafe() unsafe} {@code Access}.
+     *
+     * <p>The {@code result} array should be always created by {@link #newResultArray} method. When
+     * storing, the {@code result[0 .. newResultArray().length-1]} will be accessed, the rest
+     * elements of the array will not be touched when
+     * {@code result.length > newResultArray().length]}.
      *
      * @param input the buffer to read bytes from
      * @param off index of the first {@code byte} in the subsequence to hash
      * @param len length of the subsequence to hash
-     * @param result the container array for putting the hash results,
+     * @param result the container array for storing the hash results,
      *               should be alloced by {@link #newResultArray}
-     * @throws IllegalArgumentException if {@code off < 0} or {@code off + len > input.capacity()}
-     * or {@code len < 0}
+     * @throws NullPointerException if {@code result == null}
+     * @throws IllegalArgumentException if {@code result.length < newResultArray().length}
+     * @throws IllegalArgumentException if {@code off < 0} or {@code off + len > input.length}
+     *                                  or {@code len < 0}
      */
     public void hashBytes(final ByteBuffer input,
                           final int off, final int len, final long[] result) {
@@ -491,9 +526,9 @@ public abstract class LongTupleHashFunction implements Serializable {
     }
 
     /**
-     * @see #hashBytes(ByteBuffer, int, int, long[])
+     * The result array is allocated on the fly.
      *
-     * The result array is allocated on the fly, and no exceptions will be thrown.
+     * @see #hashBytes(ByteBuffer, int, int, long[])
      */
     @NotNull
     public long[] hashBytes(final ByteBuffer input, final int off, final int len) {
@@ -504,24 +539,33 @@ public abstract class LongTupleHashFunction implements Serializable {
     }
 
     /**
-     * Returns the hash code of bytes of the wild memory from the given address. Use with caution.
+     * Computes the hash code of bytes of the wild memory from the given address. Use with caution.
      *
      * <p>Default implementation delegates to {@link #hash(Object, Access, long, long, long[])}
      * method using {@linkplain Access#unsafe() unsafe} {@code Access}.
      *
+     * <p>The {@code result} array should be always created by {@link #newResultArray} method. When
+     * storing, the {@code result[0 .. newResultArray().length-1]} will be accessed, the rest
+     * elements of the array will not be touched when
+     * {@code result.length > newResultArray().length]}.
+     *
      * @param address the address of the first byte to hash
      * @param len length of the byte sequence to hash
-     * @param result the container array for putting the hash results,
+     * @param result the container array for storing the hash results,
      *               should be alloced by {@link #newResultArray}
+     * @throws NullPointerException if {@code result == null}
+     * @throws IllegalArgumentException if {@code result.length < newResultArray().length}
+     * @throws IllegalArgumentException if {@code off < 0} or {@code off + len > input.length}
+     *                                  or {@code len < 0}
      */
     public void hashMemory(final long address, final long len, final long[] result) {
         unsafeHash(this, null, address, len, result);
     }
 
     /**
-     * @see #hashMemory(long, long, long[])
-     *
      * The result array is allocated on the fly, and no exceptions will be thrown.
+     *
+     * @see #hashMemory(long, long, long[])
      */
     @NotNull
     public long[] hashMemory(final long address, final long len) {
@@ -531,16 +575,17 @@ public abstract class LongTupleHashFunction implements Serializable {
     }
 
     /**
-     * Shortcut for {@link #hashChars(char[], int, int, long[]) hashChars(input, 0, input.length, result)}.
+     * Shortcut for
+     * {@link #hashChars(char[], int, int, long[]) hashChars(input, 0, input.length, result)}.
      */
     public void hashChars(final char[] input, final long[] result) {
         unsafeHash(this, input, CHAR_BASE, input.length * 2L, result);
     }
 
     /**
-     * @see #hashChars(char[], long[])
-     *
      * The result array is allocated on the fly, and no exceptions will be thrown.
+     *
+     * @see #hashChars(char[], long[])
      */
     @NotNull
     public long[] hashChars(final char[] input) {
@@ -550,20 +595,27 @@ public abstract class LongTupleHashFunction implements Serializable {
     }
 
     /**
-     * Returns the hash code for bytes, as they lay in memory, of the specified subsequence
-     * of the given {@code char} array.
+     * Computes the hash code for bytes, as they lay in memory, of the specified subsequence of the
+     * given {@code char} array.
      *
      * <p>Default implementation delegates to {@link #hash(Object, Access, long, long, long[])}
      * method using {@linkplain Access#unsafe() unsafe} {@code Access}.
      *
+     * <p>The {@code result} array should be always created by {@link #newResultArray} method. When
+     * storing, the {@code result[0 .. newResultArray().length-1]} will be accessed, the rest
+     * elements of the array will not be touched when
+     * {@code result.length > newResultArray().length]}.
+     *
      * @param input the array to read data from
      * @param off index of the first {@code char} in the subsequence to hash
-     * @param len length of the subsequence to hash, in chars (i. e. the length of the bytes
-     *            sequence to hash is {@code len * 2L})
-     * @param result the container array for putting the hash results,
+     * @param len length of the subsequence to hash, in chars (i.e. the length of the bytes sequence
+     *            to hash is {@code len * 2L})
+     * @param result the container array for storing the hash results,
      *               should be alloced by {@link #newResultArray}
+     * @throws NullPointerException if {@code result == null}
+     * @throws IllegalArgumentException if {@code result.length < newResultArray().length}
      * @throws IllegalArgumentException if {@code off < 0} or {@code off + len > input.length}
-     * or {@code len < 0}
+     *                                  or {@code len < 0}
      */
     public void hashChars(final char[] input, final int off, final int len, final long[] result) {
         checkArrayOffs(input.length, off, len);
@@ -571,9 +623,9 @@ public abstract class LongTupleHashFunction implements Serializable {
     }
 
     /**
-     * @see #hashChars(char[], int, int, long[])
+     * The result array is allocated on the fly.
      *
-     * The result array is allocated on the fly, and no exceptions will be thrown.
+     * @see #hashChars(char[], int, int, long[])
      */
     @NotNull
     public long[] hashChars(final char[] input, final int off, final int len) {
@@ -584,16 +636,17 @@ public abstract class LongTupleHashFunction implements Serializable {
     }
 
     /**
-     * Shortcut for {@link #hashChars(String, int, int, long[]) hashChars(input, 0, input.length(), result)}.
+     * Shortcut for
+     * {@link #hashChars(String, int, int, long[]) hashChars(input, 0, input.length(), result)}.
      */
     public void hashChars(final String input, final long[] result) {
         VALID_STRING_HASH.hash(input, this, 0, input.length(), result);
     }
 
     /**
-     * @see #hashChars(String, long[])
-     *
      * The result array is allocated on the fly, and no exceptions will be thrown.
+     *
+     * @see #hashChars(String, long[])
      */
     @NotNull
     public long[] hashChars(final String input) {
@@ -603,20 +656,28 @@ public abstract class LongTupleHashFunction implements Serializable {
     }
 
     /**
-     * Returns the hash code for bytes of the specified subsequence of the given {@code String}'s
-     * underlying {@code char} array.
+     * Computes the hash code for bytes of the specified subsequence of the given {@code String}'s
+     * underlying {@code char} array or {@code byte} array.
      *
-     * <p>Default implementation could either delegate to {@link #hash(Object, Access, long, long, long[])}
-     * using {@link Access#toNativeCharSequence()}, or to {@link #hashChars(char[], int, int, long[])}.
+     * <p>Default implementation could either delegate to
+     * {@link #hash(Object, Access, long, long, long[])} using
+     * {@link Access#toNativeCharSequence()}, or to {@link #hashChars(char[], int, int, long[])}.
+     *
+     * <p>The {@code result} array should be always created by {@link #newResultArray} method. When
+     * storing, the {@code result[0 .. newResultArray().length-1]} will be accessed, the rest
+     * elements of the array will not be touched when
+     * {@code result.length > newResultArray().length]}.
      *
      * @param input the string which bytes to hash
      * @param off index of the first {@code char} in the subsequence to hash
-     * @param len length of the subsequence to hash, in chars (i. e. the length of the bytes
-     *            sequence to hash is {@code len * 2L})
-     * @param result the container array for putting the hash results,
+     * @param len length of the subsequence to hash, in chars (i.e. the length of the bytes sequence
+     *            to hash is {@code len * 2L})
+     * @param result the container array for storing the hash results,
      *               should be alloced by {@link #newResultArray}
-     * @throws IllegalArgumentException if {@code off < 0} or {@code off + len > input.length()}
-     * or {@code len < 0}
+     * @throws NullPointerException if {@code result == null}
+     * @throws IllegalArgumentException if {@code result.length < newResultArray().length}
+     * @throws IllegalArgumentException if {@code off < 0} or {@code off + len > input.length}
+     *                                  or {@code len < 0}
      */
     public void hashChars(final String input, final int off, final int len, final long[] result) {
         checkArrayOffs(input.length(), off, len);
@@ -624,9 +685,9 @@ public abstract class LongTupleHashFunction implements Serializable {
     }
 
     /**
-     * @see #hashChars(String, int, int long[])
+     * The result array is allocated on the fly.
      *
-     * The result array is allocated on the fly, and no exceptions will be thrown.
+     * @see #hashChars(String, int, int long[])
      */
     @NotNull
     public long[] hashChars(final String input, final int off, final int len) {
@@ -637,16 +698,17 @@ public abstract class LongTupleHashFunction implements Serializable {
     }
 
     /**
-     * Shortcut for {@link #hashChars(CharSequence, int, int, long[]) hashChars(input, 0, input.length(), result)}.
+     * Shortcut for
+     * {@link #hashChars(CharSequence, int, int, long[]) hashChars(input, 0, input.length(), result)}.
      */
     public <T extends CharSequence> void hashChars(final T input, final long[] result) {
         hashNativeChars(this, input, 0, input.length(), result);
     }
 
     /**
-     * @see #hashChars(CharSequence, long[])
-     *
      * The result array is allocated on the fly, and no exceptions will be thrown.
+     *
+     * @see #hashChars(CharSequence, long[])
      */
     @NotNull
     public <T extends CharSequence> long[] hashChars(final T input) {
@@ -656,21 +718,27 @@ public abstract class LongTupleHashFunction implements Serializable {
     }
 
     /**
-     * Returns the hash code for bytes of the specified subsequence of the given
+     * Computes the hash code for bytes of the specified subsequence of the given
      * {@code CharSequence}'s underlying {@code char} array.
      *
-     * <p>Default implementation could either delegate to {@link #hash(Object, Access, long, long, long[])}
-     * using {@link Access#toNativeCharSequence()}.
+     * <p>Default implementation delegates to {@link #hash(Object, Access, long, long, long[])}
+     * method using {@link Access#toNativeCharSequence()}.
+     *
+     * <p>The {@code result} array should be always created by {@link #newResultArray} method. When
+     * storing, the {@code result[0 .. newResultArray().length-1]} will be accessed, the rest
+     * elements of the array will not be touched when
+     * {@code result.length > newResultArray().length]}.
      *
      * @param input the char sequence which bytes to hash
      * @param off index of the first {@code char} in the subsequence to hash
-     * @param len length of the subsequence to hash, in chars (i. e. the length of the bytes
-     *            sequence to hash is {@code len * 2L})
-     * @param result the container array for putting the hash results,
+     * @param len length of the subsequence to hash, in chars (i.e. the length of the bytes sequence
+     *            to hash is {@code len * 2L})
+     * @param result the container array for storing the hash results,
      *               should be alloced by {@link #newResultArray}
-     * @param <T> the type of the input which extends CharSequence
-     * @throws IllegalArgumentException if {@code off < 0} or {@code off + len > input.length()}
-     * or {@code len < 0}
+     * @throws NullPointerException if {@code result == null}
+     * @throws IllegalArgumentException if {@code result.length < newResultArray().length}
+     * @throws IllegalArgumentException if {@code off < 0} or {@code off + len > input.length}
+     *                                  or {@code len < 0}
      */
     public <T extends CharSequence> void hashChars(final T input, final int off, final int len,
                                                    final long[] result) {
@@ -679,9 +747,9 @@ public abstract class LongTupleHashFunction implements Serializable {
     }
 
     /**
-     * @see #hashChars(CharSequence, int, int, long[])
+     * The result array is allocated on the fly.
      *
-     * The result array is allocated on the fly, and no exceptions will be thrown.
+     * @see #hashChars(CharSequence, int, int, long[])
      */
     @NotNull
     public <T extends CharSequence> long[] hashChars(final T input, final int off, final int len) {
@@ -692,16 +760,17 @@ public abstract class LongTupleHashFunction implements Serializable {
     }
 
     /**
-     * Shortcut for {@link #hashShorts(short[], int, int, long[]) hashShorts(input, 0, input.length, result)}.
+     * Shortcut for
+     * {@link #hashShorts(short[], int, int, long[]) hashShorts(input, 0, input.length, result)}.
      */
     public void hashShorts(final short[] input, final long[] result) {
         unsafeHash(this, input, SHORT_BASE, input.length * 2L, result);
     }
 
     /**
-     * @see #hashShorts(short[], long[])
-     *
      * The result array is allocated on the fly, and no exceptions will be thrown.
+     *
+     * @see #hashShorts(short[], long[])
      */
     @NotNull
     public long[] hashShorts(final short[] input) {
@@ -711,20 +780,27 @@ public abstract class LongTupleHashFunction implements Serializable {
     }
 
     /**
-     * Returns the hash code for bytes, as they lay in memory, of the specified subsequence
-     * of the given {@code short} array.
+     * Computes the hash code for bytes, as they lay in memory, of the specified subsequence of the
+     * given {@code short} array.
      *
      * <p>Default implementation delegates to {@link #hash(Object, Access, long, long, long[])}
      * method using {@linkplain Access#unsafe() unsafe} {@code Access}.
      *
+     * <p>The {@code result} array should be always created by {@link #newResultArray} method. When
+     * storing, the {@code result[0 .. newResultArray().length-1]} will be accessed, the rest
+     * elements of the array will not be touched when
+     * {@code result.length > newResultArray().length]}.
+     *
      * @param input the array to read data from
      * @param off index of the first {@code short} in the subsequence to hash
-     * @param len length of the subsequence to hash, in shorts (i. e. the length of the bytes
+     * @param len length of the subsequence to hash, in shorts (i.e. the length of the bytes
      *            sequence to hash is {@code len * 2L})
-     * @param result the container array for putting the hash results,
+     * @param result the container array for storing the hash results,
      *               should be alloced by {@link #newResultArray}
+     * @throws NullPointerException if {@code result == null}
+     * @throws IllegalArgumentException if {@code result.length < newResultArray().length}
      * @throws IllegalArgumentException if {@code off < 0} or {@code off + len > input.length}
-     * or {@code len < 0}
+     *                                  or {@code len < 0}
      */
     public void hashShorts(final short[] input, final int off, final int len, final long[] result) {
         checkArrayOffs(input.length, off, len);
@@ -732,9 +808,9 @@ public abstract class LongTupleHashFunction implements Serializable {
     }
 
     /**
-     * @see #hashShorts(short[], int, int, long[])
+     * The result array is allocated on the fly.
      *
-     * The result array is allocated on the fly, and no exceptions will be thrown.
+     * @see #hashShorts(short[], int, int, long[])
      */
     @NotNull
     public long[] hashShorts(final short[] input, final int off, final int len) {
@@ -745,16 +821,17 @@ public abstract class LongTupleHashFunction implements Serializable {
     }
 
     /**
-     * Shortcut for {@link #hashInts(int[], int, int, long[]) hashInts(input, 0, input.length, result)}.
+     * Shortcut for
+     * {@link #hashInts(int[], int, int, long[]) hashInts(input, 0, input.length, result)}.
      */
     public void hashInts(final int[] input, final long[] result) {
         unsafeHash(this, input, INT_BASE, input.length * 4L, result);
     }
 
     /**
-     * @see #hashInts(int[], long[])
-     *
      * The result array is allocated on the fly, and no exceptions will be thrown.
+     *
+     * @see #hashInts(int[], long[])
      */
     @NotNull
     public long[] hashInts(final int[] input) {
@@ -764,20 +841,27 @@ public abstract class LongTupleHashFunction implements Serializable {
     }
 
     /**
-     * Returns the hash code for bytes, as they lay in memory, of the specified subsequence
-     * of the given {@code int} array.
+     * Computes the hash code for bytes, as they lay in memory, of the specified subsequence of the
+     * given {@code int} array.
      *
      * <p>Default implementation delegates to {@link #hash(Object, Access, long, long, long[])}
      * method using {@linkplain Access#unsafe() unsafe} {@code Access}.
      *
+     * <p>The {@code result} array should be always created by {@link #newResultArray} method. When
+     * storing, the {@code result[0 .. newResultArray().length-1]} will be accessed, the rest
+     * elements of the array will not be touched when
+     * {@code result.length > newResultArray().length]}.
+     *
      * @param input the array to read data from
      * @param off index of the first {@code int} in the subsequence to hash
-     * @param len length of the subsequence to hash, in ints (i. e. the length of the bytes
-     *            sequence to hash is {@code len * 4L})
-     * @param result the container array for putting the hash results,
+     * @param len length of the subsequence to hash, in ints (i.e. the length of the bytes sequence
+     *            to hash is {@code len * 4L})
+     * @param result the container array for storing the hash results,
      *               should be alloced by {@link #newResultArray}
+     * @throws NullPointerException if {@code result == null}
+     * @throws IllegalArgumentException if {@code result.length < newResultArray().length}
      * @throws IllegalArgumentException if {@code off < 0} or {@code off + len > input.length}
-     * or {@code len < 0}
+     *                                  or {@code len < 0}
      */
     public void hashInts(final int[] input, final int off, final int len, final long[] result) {
         checkArrayOffs(input.length, off, len);
@@ -785,9 +869,9 @@ public abstract class LongTupleHashFunction implements Serializable {
     }
 
     /**
-     * @see #hashInts(int[], int, int, long[])
+     * The result array is allocated on the fly.
      *
-     * The result array is allocated on the fly, and no exceptions will be thrown.
+     * @see #hashInts(int[], int, int, long[])
      */
     @NotNull
     public long[] hashInts(final int[] input, final int off, final int len) {
@@ -798,16 +882,17 @@ public abstract class LongTupleHashFunction implements Serializable {
     }
 
     /**
-     * Shortcut for {@link #hashLongs(long[], int, int, long[]) hashLongs(input, 0, input.length, result)}.
+     * Shortcut for
+     * {@link #hashLongs(long[], int, int, long[]) hashLongs(input, 0, input.length, result)}.
      */
     public void hashLongs(final long[] input, final long[] result) {
         unsafeHash(this, input, LONG_BASE, input.length * 8L, result);
     }
 
     /**
-     * @see #hashLongs(long[], long[])
-     *
      * The result array is allocated on the fly, and no exceptions will be thrown.
+     *
+     * @see #hashLongs(long[], long[])
      */
     @NotNull
     public long[] hashLongs(final long[] input) {
@@ -817,20 +902,27 @@ public abstract class LongTupleHashFunction implements Serializable {
     }
 
     /**
-     * Returns the hash code for bytes, as they lay in memory, of the specified subsequence
-     * of the given {@code long} array.
+     * Computes the hash code for bytes, as they lay in memory, of the specified subsequence of the
+     * given {@code long} array.
      *
      * <p>Default implementation delegates to {@link #hash(Object, Access, long, long, long[])}
      * method using {@linkplain Access#unsafe() unsafe} {@code Access}.
      *
+     * <p>The {@code result} array should be always created by {@link #newResultArray} method. When
+     * storing, the {@code result[0 .. newResultArray().length-1]} will be accessed, the rest
+     * elements of the array will not be touched when
+     * {@code result.length > newResultArray().length]}.
+     *
      * @param input the array to read data from
      * @param off index of the first {@code long} in the subsequence to hash
-     * @param len length of the subsequence to hash, in longs (i. e. the length of the bytes
-     *            sequence to hash is {@code len * 8L})
-     * @param result the container array for putting the hash results,
+     * @param len length of the subsequence to hash, in longs (i.e. the length of the bytes sequence
+     *            to hash is {@code len * 8L})
+     * @param result the container array for storing the hash results,
      *               should be alloced by {@link #newResultArray}
+     * @throws NullPointerException if {@code result == null}
+     * @throws IllegalArgumentException if {@code result.length < newResultArray().length}
      * @throws IllegalArgumentException if {@code off < 0} or {@code off + len > input.length}
-     * or {@code len < 0}
+     *                                  or {@code len < 0}
      */
     public void hashLongs(final long[] input, final int off, final int len, final long[] result) {
         checkArrayOffs(input.length, off, len);
@@ -838,9 +930,9 @@ public abstract class LongTupleHashFunction implements Serializable {
     }
 
     /**
-     * @see #hashLongs(long[], int, int, long[])
+     * The result array is allocated on the fly.
      *
-     * The result array is allocated on the fly, and no exceptions will be thrown.
+     * @see #hashLongs(long[], int, int, long[])
      */
     @NotNull
     public long[] hashLongs(final long[] input, final int off, final int len) {

--- a/src/main/java/net/openhft/hashing/LongTupleHashFunction.java
+++ b/src/main/java/net/openhft/hashing/LongTupleHashFunction.java
@@ -7,6 +7,7 @@ import sun.nio.ch.DirectBuffer;
 
 import java.io.Serializable;
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 
 import static net.openhft.hashing.CharSequenceAccess.nativeCharSequenceAccess;
 import static net.openhft.hashing.UnsafeAccess.*;
@@ -101,6 +102,9 @@ public abstract class LongTupleHashFunction implements Serializable {
 
     /**
      * Returns a new-allocated result array.
+     *
+     * If the ${@code bitsLength()} returns non-multiple of 64, the implementation of this method
+     * should round-up the length to a multiple of 64 for allocating the {@code long} array.
      */
     @NotNull
     public long[] newResultArray() {
@@ -128,7 +132,7 @@ public abstract class LongTupleHashFunction implements Serializable {
     /**
      * @see #hashLong(long, long[])
      *
-     * The result array will be allocated on the fly, and no exceptions will be thrown.
+     * The result array is allocated on the fly, and no exceptions will be thrown.
      */
     @NotNull
     public long[] hashLong(final long input) {
@@ -143,7 +147,7 @@ public abstract class LongTupleHashFunction implements Serializable {
      * that accept sequences of bytes, assuming the {@code input} value is interpreted in
      * {@linkplain ByteOrder#nativeOrder() native} byte order. For example, the result of
      * {@code hashInt(v, result)} call is identical to the result of
-     * {@code hashInts(new long[] {v}, result)} call for any {@code int} value.
+     * {@code hashInts(new int[] {v}, result)} call for any {@code int} value.
      *
      * The {@code result} array should be always created by {@link #newResultArray} method.
      * When storing, the {@code result[0 .. newResultArray().length-1]} will be accessed,
@@ -158,7 +162,7 @@ public abstract class LongTupleHashFunction implements Serializable {
     /**
      * @see #hashInt(int, long[])
      *
-     * The result array will be allocated on the fly, and no exceptions will be thrown.
+     * The result array is allocated on the fly, and no exceptions will be thrown.
      */
     @NotNull
     public long[] hashInt(final int input) {
@@ -173,7 +177,7 @@ public abstract class LongTupleHashFunction implements Serializable {
      * that accept sequences of bytes, assuming the {@code input} value is interpreted in
      * {@linkplain ByteOrder#nativeOrder() native} byte order. For example, the result of
      * {@code hashShort(v, result)} call is identical to the result of
-     * {@code hashShorts(new long[] {v}, result)} call for any {@code short} value.
+     * {@code hashShorts(new short[] {v}, result)} call for any {@code short} value.
      *
      * The {@code result} array should be always created by {@link #newResultArray} method.
      * When storing, the {@code result[0 .. newResultArray().length-1]} will be accessed,
@@ -188,7 +192,7 @@ public abstract class LongTupleHashFunction implements Serializable {
     /**
      * @see #hashShort(short, long[])
      *
-     * The result array will be allocated on the fly, and no exceptions will be thrown.
+     * The result array is allocated on the fly, and no exceptions will be thrown.
      */
     @NotNull
     public long[] hashShort(final short input) {
@@ -198,21 +202,27 @@ public abstract class LongTupleHashFunction implements Serializable {
     }
 
     /**
-     * TODO
-     * Returns the hash code for the given {@code char} value; this method is consistent with
-     * {@code LongTupleHashFunction} methods that accept sequences of bytes, assuming the {@code input}
-     * value is interpreted in {@linkplain ByteOrder#nativeOrder() native} byte order. For example,
-     * the result of {@code hashChar(v, result)} call is identical to the result of
-     * {@code hashChars(new char[] {v}, result)} call for any {@code char} value.
-     * As a consequence, {@code hashChar(v, result)} call produce always the same result as {@code
-     * hashShort((short) v, result)}.
+     * Computes the hash code for the given {@code char} value, and store the results in the
+     * {@code result} array; this method is consistent with {@code LongTupleHashFunction} methods
+     * that accept sequences of bytes, assuming the {@code input} value is interpreted in
+     * {@linkplain ByteOrder#nativeOrder() native} byte order. For example, the result of
+     * {@code hashChar(v, result)} call is identical to the result of
+     * {@code hashChars(new char[] {v}, result)} call for any {@code short} value.
+     *
+     * The {@code result} array should be always created by {@link #newResultArray} method.
+     * When storing, the {@code result[0 .. newResultArray().length-1]} will be accessed,
+     * the rest elements of the array will not be touched when
+     * {@code result.length > newResultArray().length]}.
+     *
+     * @throws NullPointerException if {@code result == null}
+     * @throws IllegalArgumentException if {@code result.length < newResultArray().length}
      */
     public abstract void hashChar(char input, long[] result);
 
     /**
      * @see #hashChar(char, long[])
      *
-     * The result array will be allocated on the fly, and no exceptions will be thrown.
+     * The result array is allocated on the fly, and no exceptions will be thrown.
      */
     @NotNull
     public long[] hashChar(final char input) {
@@ -222,17 +232,27 @@ public abstract class LongTupleHashFunction implements Serializable {
     }
 
     /**
-     * Returns the hash code for the given {@code byte} value. This method is consistent with
-     * {@code LongTupleHashFunction} methods that accept sequences of bytes. For example, the result of
+     * Computes the hash code for the given {@code byte} value, and store the results in the
+     * {@code result} array; this method is consistent with {@code LongTupleHashFunction} methods
+     * that accept sequences of bytes, assuming the {@code input} value is interpreted in
+     * {@linkplain ByteOrder#nativeOrder() native} byte order. For example, the result of
      * {@code hashByte(v, result)} call is identical to the result of
      * {@code hashBytes(new byte[] {v}, result)} call for any {@code byte} value.
+     *
+     * The {@code result} array should be always created by {@link #newResultArray} method.
+     * When storing, the {@code result[0 .. newResultArray().length-1]} will be accessed,
+     * the rest elements of the array will not be touched when
+     * {@code result.length > newResultArray().length]}.
+     *
+     * @throws NullPointerException if {@code result == null}
+     * @throws IllegalArgumentException if {@code result.length < newResultArray().length}
      */
     public abstract void hashByte(byte input, long[] result);
 
     /**
      * @see #hashByte(byte, long[])
      *
-     * The result array will be allocated on the fly, and no exceptions will be thrown.
+     * The result array is allocated on the fly, and no exceptions will be thrown.
      */
     @NotNull
     public long[] hashByte(final byte input) {
@@ -242,15 +262,24 @@ public abstract class LongTupleHashFunction implements Serializable {
     }
 
     /**
-     * Returns the hash code for the empty (zero-length) bytes sequence,
-     * for example {@code hashBytes(new byte[0], result)}.
+     * Computes the hash code for the empty (zero-length) bytes sequence, and store the results in
+     * the {@code result} array. For example, the result of {@code hashVoid(result)} call is
+     * identical to the result of {@code hashBytes(new byte[0], result)} call.
+     *
+     * The {@code result} array should be always created by {@link #newResultArray} method.
+     * When storing, the {@code result[0 .. newResultArray().length-1]} will be accessed,
+     * the rest elements of the array will not be touched when
+     * {@code result.length > newResultArray().length]}.
+     *
+     * @throws NullPointerException if {@code result == null}
+     * @throws IllegalArgumentException if {@code result.length < newResultArray().length}
      */
     public abstract void hashVoid(long[] result);
 
     /**
      * @see #hashVoid(long[])
      *
-     * The result array will be allocated on the fly, and no exceptions will be thrown.
+     * The result array is allocated on the fly, and no exceptions will be thrown.
      */
     @NotNull
     public long[] hashVoid() {
@@ -260,6 +289,7 @@ public abstract class LongTupleHashFunction implements Serializable {
     }
 
     /**
+     * TODO
      * Returns the hash code for {@code len} continuous bytes of the given {@code input} object,
      * starting from the given offset. The abstraction of input as ordered byte sequence and
      * "offset within the input" is defined by the given {@code access} strategy.
@@ -281,9 +311,9 @@ public abstract class LongTupleHashFunction implements Serializable {
                                   long off, long len, long[] result);
 
     /**
-     * @see #hash(T, Access, long, long, long[])
+     * @see #hash(Object, Access, long, long, long[])
      *
-     * The result array will be allocated on the fly, and no exceptions will be thrown.
+     * The result array is allocated on the fly, and no exceptions will be thrown.
      */
     @NotNull
     public <T> long[] hash(@Nullable final T input, final Access<T> access,
@@ -305,7 +335,7 @@ public abstract class LongTupleHashFunction implements Serializable {
     /**
      * @see #hashBoolean(boolean, long[])
      *
-     * The result array will be allocated on the fly, and no exceptions will be thrown.
+     * The result array is allocated on the fly, and no exceptions will be thrown.
      */
     @NotNull
     public long[] hashBoolean(final boolean input) {
@@ -324,7 +354,7 @@ public abstract class LongTupleHashFunction implements Serializable {
     /**
      * @see #hashBooleans(boolean[], long[])
      *
-     * The result array will be allocated on the fly, and no exceptions will be thrown.
+     * The result array is allocated on the fly, and no exceptions will be thrown.
      */
     @NotNull
     public long[] hashBooleans(final boolean[] input) {
@@ -356,7 +386,7 @@ public abstract class LongTupleHashFunction implements Serializable {
     /**
      * @see #hashBooleans(boolean[], int, int, long[])
      *
-     * The result array will be allocated on the fly, and no exceptions will be thrown.
+     * The result array is allocated on the fly, and no exceptions will be thrown.
      */
     @NotNull
     public long[] hashBooleans(final boolean[] input, final int off, final int len) {
@@ -376,7 +406,7 @@ public abstract class LongTupleHashFunction implements Serializable {
     /**
      * @see #hashBytes(byte[], long[])
      *
-     * The result array will be allocated on the fly, and no exceptions will be thrown.
+     * The result array is allocated on the fly, and no exceptions will be thrown.
      */
     @NotNull
     public long[] hashBytes(final byte[] input) {
@@ -407,7 +437,7 @@ public abstract class LongTupleHashFunction implements Serializable {
     /**
      * @see #hashBytes(byte[], int, int, long[])
      *
-     * The result array will be allocated on the fly, and no exceptions will be thrown.
+     * The result array is allocated on the fly, and no exceptions will be thrown.
      */
     @NotNull
     public long[] hashBytes(final byte[] input, final int off, final int len) {
@@ -428,7 +458,7 @@ public abstract class LongTupleHashFunction implements Serializable {
     /**
      * @see #hashBytes(ByteBuffer, long[])
      *
-     * The result array will be allocated on the fly, and no exceptions will be thrown.
+     * The result array is allocated on the fly, and no exceptions will be thrown.
      */
     @NotNull
     public long[] hashBytes(final ByteBuffer input) {
@@ -463,7 +493,7 @@ public abstract class LongTupleHashFunction implements Serializable {
     /**
      * @see #hashBytes(ByteBuffer, int, int, long[])
      *
-     * The result array will be allocated on the fly, and no exceptions will be thrown.
+     * The result array is allocated on the fly, and no exceptions will be thrown.
      */
     @NotNull
     public long[] hashBytes(final ByteBuffer input, final int off, final int len) {
@@ -491,7 +521,7 @@ public abstract class LongTupleHashFunction implements Serializable {
     /**
      * @see #hashMemory(long, long, long[])
      *
-     * The result array will be allocated on the fly, and no exceptions will be thrown.
+     * The result array is allocated on the fly, and no exceptions will be thrown.
      */
     @NotNull
     public long[] hashMemory(final long address, final long len) {
@@ -510,7 +540,7 @@ public abstract class LongTupleHashFunction implements Serializable {
     /**
      * @see #hashChars(char[], long[])
      *
-     * The result array will be allocated on the fly, and no exceptions will be thrown.
+     * The result array is allocated on the fly, and no exceptions will be thrown.
      */
     @NotNull
     public long[] hashChars(final char[] input) {
@@ -543,7 +573,7 @@ public abstract class LongTupleHashFunction implements Serializable {
     /**
      * @see #hashChars(char[], int, int, long[])
      *
-     * The result array will be allocated on the fly, and no exceptions will be thrown.
+     * The result array is allocated on the fly, and no exceptions will be thrown.
      */
     @NotNull
     public long[] hashChars(final char[] input, final int off, final int len) {
@@ -563,7 +593,7 @@ public abstract class LongTupleHashFunction implements Serializable {
     /**
      * @see #hashChars(String, long[])
      *
-     * The result array will be allocated on the fly, and no exceptions will be thrown.
+     * The result array is allocated on the fly, and no exceptions will be thrown.
      */
     @NotNull
     public long[] hashChars(final String input) {
@@ -596,7 +626,7 @@ public abstract class LongTupleHashFunction implements Serializable {
     /**
      * @see #hashChars(String, int, int long[])
      *
-     * The result array will be allocated on the fly, and no exceptions will be thrown.
+     * The result array is allocated on the fly, and no exceptions will be thrown.
      */
     @NotNull
     public long[] hashChars(final String input, final int off, final int len) {
@@ -607,16 +637,16 @@ public abstract class LongTupleHashFunction implements Serializable {
     }
 
     /**
-     * Shortcut for {@link #hashChars(T, int, int, result) hashChars(input, 0, input.length(), result)}.
+     * Shortcut for {@link #hashChars(CharSequence, int, int, long[]) hashChars(input, 0, input.length(), result)}.
      */
     public <T extends CharSequence> void hashChars(final T input, final long[] result) {
         hashNativeChars(this, input, 0, input.length(), result);
     }
 
     /**
-     * @see #hashChars(T, long[])
+     * @see #hashChars(CharSequence, long[])
      *
-     * The result array will be allocated on the fly, and no exceptions will be thrown.
+     * The result array is allocated on the fly, and no exceptions will be thrown.
      */
     @NotNull
     public <T extends CharSequence> long[] hashChars(final T input) {
@@ -629,7 +659,7 @@ public abstract class LongTupleHashFunction implements Serializable {
      * Returns the hash code for bytes of the specified subsequence of the given
      * {@code CharSequence}'s underlying {@code char} array.
      *
-     * <p>Default implementation could either delegate to {@link #hash(Object, Access, long, long, result)}
+     * <p>Default implementation could either delegate to {@link #hash(Object, Access, long, long, long[])}
      * using {@link Access#toNativeCharSequence()}.
      *
      * @param input the char sequence which bytes to hash
@@ -649,9 +679,9 @@ public abstract class LongTupleHashFunction implements Serializable {
     }
 
     /**
-     * @see #hashChars(T, int, int, long[])
+     * @see #hashChars(CharSequence, int, int, long[])
      *
-     * The result array will be allocated on the fly, and no exceptions will be thrown.
+     * The result array is allocated on the fly, and no exceptions will be thrown.
      */
     @NotNull
     public <T extends CharSequence> long[] hashChars(final T input, final int off, final int len) {
@@ -671,7 +701,7 @@ public abstract class LongTupleHashFunction implements Serializable {
     /**
      * @see #hashShorts(short[], long[])
      *
-     * The result array will be allocated on the fly, and no exceptions will be thrown.
+     * The result array is allocated on the fly, and no exceptions will be thrown.
      */
     @NotNull
     public long[] hashShorts(final short[] input) {
@@ -704,7 +734,7 @@ public abstract class LongTupleHashFunction implements Serializable {
     /**
      * @see #hashShorts(short[], int, int, long[])
      *
-     * The result array will be allocated on the fly, and no exceptions will be thrown.
+     * The result array is allocated on the fly, and no exceptions will be thrown.
      */
     @NotNull
     public long[] hashShorts(final short[] input, final int off, final int len) {
@@ -724,7 +754,7 @@ public abstract class LongTupleHashFunction implements Serializable {
     /**
      * @see #hashInts(int[], long[])
      *
-     * The result array will be allocated on the fly, and no exceptions will be thrown.
+     * The result array is allocated on the fly, and no exceptions will be thrown.
      */
     @NotNull
     public long[] hashInts(final int[] input) {
@@ -757,7 +787,7 @@ public abstract class LongTupleHashFunction implements Serializable {
     /**
      * @see #hashInts(int[], int, int, long[])
      *
-     * The result array will be allocated on the fly, and no exceptions will be thrown.
+     * The result array is allocated on the fly, and no exceptions will be thrown.
      */
     @NotNull
     public long[] hashInts(final int[] input, final int off, final int len) {
@@ -777,7 +807,7 @@ public abstract class LongTupleHashFunction implements Serializable {
     /**
      * @see #hashLongs(long[], long[])
      *
-     * The result array will be allocated on the fly, and no exceptions will be thrown.
+     * The result array is allocated on the fly, and no exceptions will be thrown.
      */
     @NotNull
     public long[] hashLongs(final long[] input) {
@@ -810,7 +840,7 @@ public abstract class LongTupleHashFunction implements Serializable {
     /**
      * @see #hashLongs(long[], int, int, long[])
      *
-     * The result array will be allocated on the fly, and no exceptions will be thrown.
+     * The result array is allocated on the fly, and no exceptions will be thrown.
      */
     @NotNull
     public long[] hashLongs(final long[] input, final int off, final int len) {

--- a/src/main/java/net/openhft/hashing/LongTupleHashFunction.java
+++ b/src/main/java/net/openhft/hashing/LongTupleHashFunction.java
@@ -1,0 +1,410 @@
+package net.openhft.hashing;
+
+import org.jetbrains.annotations.NotNull;
+import sun.nio.ch.DirectBuffer;
+
+import java.nio.ByteBuffer;
+
+import static net.openhft.hashing.CharSequenceAccess.nativeCharSequenceAccess;
+import static net.openhft.hashing.UnsafeAccess.*;
+
+public abstract class LongTupleHashFunction extends LongHashFunction {
+    private static final long serialVersionUID = 0L;
+
+    public abstract int bits();
+    public long[] newLongTuple() {
+	return new long[(bits() + 63) / 64];
+    }
+    public long highMask() {
+        final int bitsInHighM1 = (bits() - 1) & 63;
+        return ((1L << bitsInHighM1) << 1) - 1;
+    }
+
+    /**
+     * Returns a hash function implementing
+     * <a href="https://github.com/aappleby/smhasher/blob/master/src/MurmurHash3.cpp">MurmurHash3
+     * algorithm</a> without seed values. This implementation produces equal results for equal input
+     * on platforms with different {@link ByteOrder}, but is slower on big-endian platforms than on
+     * little-endian.
+     *
+     * @see #murmur_3(long)
+     */
+    public static LongTupleHashFunction murmur_3() {
+        return MurmurHash_3.asLongTupleHashFunctionWithoutSeed();
+    }
+
+    /**
+     * Returns a hash function implementing
+     * <a href="https://github.com/aappleby/smhasher/blob/master/src/MurmurHash3.cpp">MurmurHash3
+     * algorithm</a> with the given seed value. This implementation produces equal results for equal
+     * input on platforms with different {@link ByteOrder}, but is slower on big-endian platforms
+     * than on little-endian.
+     *
+     * @see #murmur_3()
+     */
+    public static LongTupleHashFunction murmur_3(long seed) {
+        return MurmurHash_3.asLongTupleHashFunctionWithSeed(seed);
+    }
+
+    public abstract long hashLong(long input, long[] result);
+    public long hashLong(final long input) {
+        return hashLong(input, null);
+    }
+    public long[] hashTupleLong(final long input) {
+        final long[] result = newLongTuple();
+        hashLong(input, result);
+	return result;
+    }
+
+    public abstract long hashInt(int input, long[] result);
+    public long hashInt(final int input) {
+        return hashInt(input, null);
+    }
+    public long[] hashTupleInt(final int input) {
+        final long[] result = newLongTuple();
+        hashInt(input, result);
+	return result;
+    }
+
+    public abstract long hashShort(short input, long[] result);
+    public long hashShort(final short input) {
+        return hashShort(input, null);
+    }
+    public long[] hashTupleShort(final short input) {
+        final long[] result = newLongTuple();
+        hashShort(input, result);
+	return result;
+    }
+
+    public abstract long hashChar(char input, long[] result);
+    public long hashChar(final char input) {
+        return hashChar(input, null);
+    }
+    public long[] hashTupleChar(final char input) {
+        final long[] result = newLongTuple();
+        hashChar(input, result);
+	return result;
+    }
+
+    public abstract long hashByte(byte input, long[] result);
+    public long hashByte(final byte input) {
+        return hashByte(input, null);
+    }
+    public long[] hashTupleByte(final byte input) {
+        final long[] result = newLongTuple();
+        hashByte(input, result);
+	return result;
+    }
+
+    public abstract long[] hashTupleVoid();
+    public long hashVoid() {
+        return hashTupleVoid()[0];
+    }
+
+    public abstract <T> long hash(T input, Access<T> access, long off, long len, long[] result);
+    public <T> long hash(final T input, final Access<T> access, final long off, final long len) {
+        return hash(input, access, off, len, null);
+    }
+    public <T> long[] hashTuple(final T input, final Access<T> access, final long off, final long len) {
+        final long[] result = newLongTuple();
+        hash(input, access, off, len, result);
+	return result;
+    }
+
+    private long unsafeHash(final Object input, final long off, final long len) {
+        return hash(input, UnsafeAccess.INSTANCE, off, len, null);
+    }
+    private long unsafeHash(final Object input, final long off, final long len, long[] result) {
+        return hash(input, UnsafeAccess.INSTANCE, off, len, result);
+    }
+    private long[] unsafeHashTuple(final Object input, final long off, final long len) {
+        final long[] result = newLongTuple();
+        hash(input, UnsafeAccess.INSTANCE, off, len, result);
+	return result;
+    }
+
+    public long hashBoolean(final boolean input, final long[] result) {
+        return hashByte(input ? TRUE_BYTE_VALUE : FALSE_BYTE_VALUE, result);
+    }
+    public long hashBoolean(final boolean input) {
+        return hashByte(input ? TRUE_BYTE_VALUE : FALSE_BYTE_VALUE, null);
+    }
+    public long[] hashTupleBoolean(final boolean input) {
+        final long[] result = newLongTuple();
+        hashByte(input ? TRUE_BYTE_VALUE : FALSE_BYTE_VALUE, result);
+	return result;
+    }
+
+    public long hashBooleans(@NotNull final boolean[] input, final long[] result) {
+        return unsafeHash(input, BOOLEAN_BASE, input.length, result);
+    }
+    public long hashBooleans(@NotNull final boolean[] input) {
+        return unsafeHash(input, BOOLEAN_BASE, input.length, null);
+    }
+    public long[] hashTupleBooleans(@NotNull final boolean[] input) {
+        final long[] result = newLongTuple();
+        unsafeHash(input, BOOLEAN_BASE, input.length, result);
+	return result;
+    }
+
+    public long hashBooleans(@NotNull final boolean[] input, final int off, final int len, final long[] result) {
+        checkArrayOffs(input.length, off, len);
+        return unsafeHash(input, BOOLEAN_BASE + off, len, result);
+    }
+    public long hashBooleans(@NotNull final boolean[] input, final int off, final int len) {
+        checkArrayOffs(input.length, off, len);
+        return unsafeHash(input, BOOLEAN_BASE + off, len, null);
+    }
+    public long[] hashTupleBooleans(@NotNull final boolean[] input, final int off, final int len) {
+        checkArrayOffs(input.length, off, len);
+        final long[] result = newLongTuple();
+        unsafeHash(input, BOOLEAN_BASE + off, len, result);
+	return result;
+    }
+
+    public long hashBytes(@NotNull final byte[] input, final long[] result) {
+        return unsafeHash(input, BYTE_BASE, input.length, result);
+    }
+    public long hashBytes(@NotNull final byte[] input) {
+        return unsafeHash(input, BYTE_BASE, input.length, null);
+    }
+    public long[] hashTupleBytes(@NotNull final byte[] input) {
+        final long[] result = newLongTuple();
+        unsafeHash(input, BYTE_BASE, input.length, result);
+	return result;
+    }
+
+    public long hashBytes(@NotNull final byte[] input, final int off, final int len, final long[] result) {
+        checkArrayOffs(input.length, off, len);
+        return unsafeHash(input, BYTE_BASE + off, len, result);
+    }
+    public long hashBytes(@NotNull final byte[] input, final int off, final int len) {
+        checkArrayOffs(input.length, off, len);
+        return unsafeHash(input, BYTE_BASE + off, len, null);
+    }
+    public long[] hashTupleBytes(@NotNull final byte[] input, final int off, final int len) {
+        checkArrayOffs(input.length, off, len);
+        final long[] result = newLongTuple();
+        unsafeHash(input, BYTE_BASE + off, len, result);
+	return result;
+    }
+
+    public long hashBytes(final ByteBuffer input, final long[] result) {
+        return hashByteBuffer(input, input.position(), input.remaining(), result);
+    }
+    public long hashBytes(final ByteBuffer input) {
+        return hashByteBuffer(input, input.position(), input.remaining(), null);
+    }
+    public long[] hashTupleBytes(final ByteBuffer input) {
+        final long[] result = newLongTuple();
+        hashByteBuffer(input, input.position(), input.remaining(), result);
+	return result;
+    }
+
+    public long hashBytes(@NotNull final ByteBuffer input, final int off, final int len, final long[] result) {
+        checkArrayOffs(input.capacity(), off, len);
+        return hashByteBuffer(input, off, len, result);
+    }
+    public long hashBytes(@NotNull final ByteBuffer input, final int off, final int len) {
+        checkArrayOffs(input.capacity(), off, len);
+        return hashByteBuffer(input, off, len, null);
+    }
+    public long[] hashTupleBytes(@NotNull final ByteBuffer input, final int off, final int len) {
+        checkArrayOffs(input.capacity(), off, len);
+        final long[] result = newLongTuple();
+        hashByteBuffer(input, off, len, result);
+	return result;
+    }
+
+    private long hashByteBuffer(@NotNull final ByteBuffer input, final int off, final int len, final long[] result) {
+        if (input.hasArray()) {
+            return unsafeHash(input.array(), BYTE_BASE + input.arrayOffset() + off, len, result);
+        } else if (input instanceof DirectBuffer) {
+            return unsafeHash(null, ((DirectBuffer) input).address() + off, len, result);
+        } else {
+            return hash(input, ByteBufferAccess.INSTANCE, off, len, result);
+        }
+    }
+
+    public long hashMemory(final long address, final long len, final long[] result) {
+        return unsafeHash(null, address, len, result);
+    }
+    public long hashMemory(final long address, final long len) {
+        return unsafeHash(null, address, len, null);
+    }
+    public long[] hashTupleMemory(final long address, final long len) {
+        final long[] result = newLongTuple();
+        unsafeHash(null, address, len, result);
+	return result;
+    }
+
+    public long hashChars(@NotNull final char[] input, final long[] result) {
+        return unsafeHash(input, CHAR_BASE, input.length * 2L, result);
+    }
+    public long hashChars(@NotNull final char[] input) {
+        return unsafeHash(input, CHAR_BASE, input.length * 2L, null);
+    }
+    public long[] hashTupleChars(@NotNull final char[] input) {
+        final long[] result = newLongTuple();
+        unsafeHash(input, CHAR_BASE, input.length * 2L, result);
+	return result;
+    }
+
+    public long hashChars(@NotNull final char[] input, final int off, final int len, final long[] result) {
+        checkArrayOffs(input.length, off, len);
+        return unsafeHash(input, CHAR_BASE + (off * 2L), len * 2L, result);
+    }
+    public long hashChars(@NotNull final char[] input, final int off, final int len) {
+        checkArrayOffs(input.length, off, len);
+        return unsafeHash(input, CHAR_BASE + (off * 2L), len * 2L, null);
+    }
+    public long[] hashTupleChars(@NotNull final char[] input, final int off, final int len) {
+        checkArrayOffs(input.length, off, len);
+        final long[] result = newLongTuple();
+        unsafeHash(input, CHAR_BASE + (off * 2L), len * 2L, result);
+	return result;
+    }
+
+    public long hashChars(@NotNull final String input, final long[] result) {
+        return stringHash.longHash(input, this, 0, input.length(), result);
+    }
+    public long hashChars(@NotNull final String input) {
+        return stringHash.longHash(input, this, 0, input.length(), null);
+    }
+    public long[] hashTupleChars(@NotNull final String input) {
+        final long[] result = newLongTuple();
+        stringHash.longHash(input, this, 0, input.length(), result);
+	return result;
+    }
+
+    public long hashChars(@NotNull final String input, final int off, final int len, final long[] result) {
+        checkArrayOffs(input.length(), off, len);
+        return stringHash.longHash(input, this, off, len, result);
+    }
+    public long hashChars(@NotNull final String input, final int off, final int len) {
+        checkArrayOffs(input.length(), off, len);
+        return stringHash.longHash(input, this, off, len, null);
+    }
+    public long[] hashTupleChars(@NotNull final String input, final int off, final int len) {
+        checkArrayOffs(input.length(), off, len);
+        final long[] result = newLongTuple();
+        stringHash.longHash(input, this, off, len, result);
+	return result;
+    }
+
+    public long hashChars(@NotNull final StringBuilder input, final long[] result) {
+        return hashNativeChars(input, result);
+    }
+    public long hashChars(@NotNull final StringBuilder input) {
+        return hashNativeChars(input, null);
+    }
+    public long[] hashTupleChars(@NotNull final StringBuilder input) {
+        final long[] result = newLongTuple();
+        hashNativeChars(input, result);
+        return result;
+    }
+
+    public long hashChars(@NotNull final StringBuilder input, final int off, final int len, final long[] result) {
+        checkArrayOffs(input.length(), off, len);
+        return hashNativeChars(input, off, len, result);
+    }
+    public long hashChars(@NotNull final StringBuilder input, final int off, final int len) {
+        checkArrayOffs(input.length(), off, len);
+        return hashNativeChars(input, off, len, null);
+    }
+    public long[] hashTupleChars(@NotNull final StringBuilder input, final int off, final int len) {
+        checkArrayOffs(input.length(), off, len);
+        final long[] result = newLongTuple();
+        hashNativeChars(input, off, len, result);
+	return result;
+    }
+
+    long hashNativeChars(final CharSequence input, final long[] result) {
+        return hashNativeChars(input, 0, input.length(), result);
+    }
+
+    long hashNativeChars(final CharSequence input, final int off, final int len, final long[] result) {
+        return hash(input, nativeCharSequenceAccess(), off * 2L, len * 2L, result);
+    }
+
+    public long hashShorts(@NotNull final short[] input, final long[] result) {
+        return unsafeHash(input, SHORT_BASE, input.length * 2L, result);
+    }
+    public long hashShorts(@NotNull final short[] input) {
+        return unsafeHash(input, SHORT_BASE, input.length * 2L, null);
+    }
+    public long[] hashTupleShorts(@NotNull final short[] input) {
+        final long[] result = newLongTuple();
+        unsafeHash(input, SHORT_BASE, input.length * 2L, result);
+	return result;
+    }
+
+    public long hashShorts(@NotNull final short[] input, final int off, final int len, final long[] result) {
+        checkArrayOffs(input.length, off, len);
+        return unsafeHash(input, SHORT_BASE + (off * 2L), len * 2L, result);
+    }
+    public long hashShorts(@NotNull final short[] input, final int off, final int len) {
+        checkArrayOffs(input.length, off, len);
+        return unsafeHash(input, SHORT_BASE + (off * 2L), len * 2L, null);
+    }
+    public long[] hashTupleShorts(@NotNull final short[] input, final int off, final int len) {
+        checkArrayOffs(input.length, off, len);
+        final long[] result = newLongTuple();
+        unsafeHash(input, SHORT_BASE + (off * 2L), len * 2L, result);
+	return result;
+    }
+
+    public long hashInts(@NotNull final int[] input, final long[] result) {
+        return unsafeHash(input, INT_BASE, input.length * 4L, result);
+    }
+    public long hashInts(@NotNull final int[] input) {
+        return unsafeHash(input, INT_BASE, input.length * 4L, null);
+    }
+    public long[] hashTupleInts(@NotNull final int[] input) {
+        final long[] result = newLongTuple();
+        unsafeHash(input, INT_BASE, input.length * 4L, result);
+        return result;
+    }
+
+    public long hashInts(@NotNull final int[] input, final int off, final int len, final long[] result) {
+        checkArrayOffs(input.length, off, len);
+        return unsafeHash(input, INT_BASE + (off * 4L), len * 4L, result);
+    }
+    public long hashInts(@NotNull final int[] input, final int off, final int len) {
+        checkArrayOffs(input.length, off, len);
+        return unsafeHash(input, INT_BASE + (off * 4L), len * 4L, null);
+    }
+    public long[] hashTupleInts(@NotNull final int[] input, final int off, final int len) {
+        checkArrayOffs(input.length, off, len);
+        final long[] result = newLongTuple();
+        unsafeHash(input, INT_BASE + (off * 4L), len * 4L, result);
+	return result;
+    }
+
+    public long hashLongs(@NotNull final long[] input, final long[] result) {
+        return unsafeHash(input, LONG_BASE, input.length * 8L, result);
+    }
+    public long hashLongs(@NotNull final long[] input) {
+        return unsafeHash(input, LONG_BASE, input.length * 8L, null);
+    }
+    public long[] hashTupleLongs(@NotNull final long[] input) {
+        final long[] result = newLongTuple();
+        unsafeHash(input, LONG_BASE, input.length * 8L, result);
+	return result;
+    }
+
+    public long hashLongs(@NotNull final long[] input, final int off, final int len, final long[] result) {
+        checkArrayOffs(input.length, off, len);
+        return unsafeHash(input, LONG_BASE + (off * 8L), len * 8L, result);
+    }
+    public long hashLongs(@NotNull final long[] input, final int off, final int len) {
+        checkArrayOffs(input.length, off, len);
+        return unsafeHash(input, LONG_BASE + (off * 8L), len * 8L, null);
+    }
+    public long[] hashTupleLongs(@NotNull final long[] input, final int off, final int len) {
+        checkArrayOffs(input.length, off, len);
+        final long[] result = newLongTuple();
+        unsafeHash(input, LONG_BASE + (off * 8L), len * 8L, result);
+	return result;
+    }
+}

--- a/src/main/java/net/openhft/hashing/MetroHash.java
+++ b/src/main/java/net/openhft/hashing/MetroHash.java
@@ -1,7 +1,7 @@
 package net.openhft.hashing;
 
 import static java.nio.ByteOrder.LITTLE_ENDIAN;
-import static net.openhft.hashing.LongHashFunction.NATIVE_LITTLE_ENDIAN;
+import static net.openhft.hashing.Util.NATIVE_LITTLE_ENDIAN;
 
 class MetroHash {
     private static final MetroHash INSTANCE = new MetroHash();

--- a/src/main/java/net/openhft/hashing/ModernHotSpotStringHash.java
+++ b/src/main/java/net/openhft/hashing/ModernHotSpotStringHash.java
@@ -17,7 +17,9 @@
 package net.openhft.hashing;
 
 import java.lang.reflect.Field;
+import javax.annotation.ParametersAreNonnullByDefault;
 
+@ParametersAreNonnullByDefault
 enum ModernHotSpotStringHash implements StringHash {
     INSTANCE;
 
@@ -39,8 +41,9 @@ enum ModernHotSpotStringHash implements StringHash {
     }
 
     @Override
-    public long longHash(String s, LongTupleHashFunction hashFunction, int off, int len, long[] result) {
-        char[] value = (char[]) UnsafeAccess.UNSAFE.getObject(s, valueOffset);
-        return hashFunction.hashChars(value, off, len, result);
+    public void hash(final String s, final LongTupleHashFunction hashFunction,
+                    final int off, final int len, final long[] result) {
+        final char[] value = (char[]) UnsafeAccess.UNSAFE.getObject(s, valueOffset);
+        hashFunction.hashChars(value, off, len, result);
     }
 }

--- a/src/main/java/net/openhft/hashing/ModernHotSpotStringHash.java
+++ b/src/main/java/net/openhft/hashing/ModernHotSpotStringHash.java
@@ -37,4 +37,10 @@ enum ModernHotSpotStringHash implements StringHash {
         char[] value = (char[]) UnsafeAccess.UNSAFE.getObject(s, valueOffset);
         return hashFunction.hashChars(value, off, len);
     }
+
+    @Override
+    public long longHash(String s, LongTupleHashFunction hashFunction, int off, int len, long[] result) {
+        char[] value = (char[]) UnsafeAccess.UNSAFE.getObject(s, valueOffset);
+        return hashFunction.hashChars(value, off, len, result);
+    }
 }

--- a/src/main/java/net/openhft/hashing/StringHash.java
+++ b/src/main/java/net/openhft/hashing/StringHash.java
@@ -16,8 +16,10 @@
 
 package net.openhft.hashing;
 
-interface StringHash {
+import javax.annotation.ParametersAreNonnullByDefault;
 
+@ParametersAreNonnullByDefault
+interface StringHash {
     long longHash(String s, LongHashFunction hashFunction, int off, int len);
-    long longHash(String s, LongTupleHashFunction hashFunction, int off, int len, long[] result);
+    void hash(String s, LongTupleHashFunction hashFunction, int off, int len, long[] result);
 }

--- a/src/main/java/net/openhft/hashing/StringHash.java
+++ b/src/main/java/net/openhft/hashing/StringHash.java
@@ -19,4 +19,5 @@ package net.openhft.hashing;
 interface StringHash {
 
     long longHash(String s, LongHashFunction hashFunction, int off, int len);
+    long longHash(String s, LongTupleHashFunction hashFunction, int off, int len, long[] result);
 }

--- a/src/main/java/net/openhft/hashing/UnknownJvmStringHash.java
+++ b/src/main/java/net/openhft/hashing/UnknownJvmStringHash.java
@@ -23,4 +23,9 @@ enum UnknownJvmStringHash implements StringHash {
     public long longHash(String s, LongHashFunction hashFunction, int off, int len) {
         return hashFunction.hashNativeChars(s, off, len);
     }
+
+    @Override
+    public long longHash(String s, LongTupleHashFunction hashFunction, int off, int len, long[] result) {
+        return hashFunction.hashNativeChars(s, off, len, result);
+    }
 }

--- a/src/main/java/net/openhft/hashing/UnknownJvmStringHash.java
+++ b/src/main/java/net/openhft/hashing/UnknownJvmStringHash.java
@@ -16,6 +16,9 @@
 
 package net.openhft.hashing;
 
+import javax.annotation.ParametersAreNonnullByDefault;
+
+@ParametersAreNonnullByDefault
 enum UnknownJvmStringHash implements StringHash {
     INSTANCE;
 
@@ -25,7 +28,8 @@ enum UnknownJvmStringHash implements StringHash {
     }
 
     @Override
-    public long longHash(String s, LongTupleHashFunction hashFunction, int off, int len, long[] result) {
-        return hashFunction.hashNativeChars(s, off, len, result);
+    public void hash(final String s, final LongTupleHashFunction hashFunction,
+                    final int off, final int len, final long[] result) {
+        LongTupleHashFunction.hashNativeChars(hashFunction, s, off, len, result);
     }
 }

--- a/src/main/java/net/openhft/hashing/UnsafeAccess.java
+++ b/src/main/java/net/openhft/hashing/UnsafeAccess.java
@@ -22,10 +22,11 @@ import java.lang.reflect.Field;
 import java.nio.ByteOrder;
 
 import static net.openhft.hashing.Primitives.*;
+import static net.openhft.hashing.Util.NATIVE_LITTLE_ENDIAN;
 
 class UnsafeAccess extends Access<Object> {
-    public static final UnsafeAccess INSTANCE;
-    static final UnsafeAccess OLD_INSTANCE = ByteOrder.nativeOrder() == ByteOrder.LITTLE_ENDIAN
+    static final UnsafeAccess INSTANCE;
+    static final UnsafeAccess OLD_INSTANCE = NATIVE_LITTLE_ENDIAN
                                              ? new OldUnsafeAccessLittleEndian()
                                              : new OldUnsafeAccessBigEndian();
 
@@ -36,6 +37,9 @@ class UnsafeAccess extends Access<Object> {
     static final long SHORT_BASE;
     static final long INT_BASE;
     static final long LONG_BASE;
+
+    static final byte TRUE_BYTE_VALUE;
+    static final byte FALSE_BYTE_VALUE;
 
     static {
         try {
@@ -56,10 +60,14 @@ class UnsafeAccess extends Access<Object> {
         try {
             inst.getByte(new byte[1], BYTE_BASE);
         } catch (final Throwable e) {
+            // Unsafe in pre-Nougat Android does not have getByte(), fall back to workround
             inst = OLD_INSTANCE;
         } finally {
             INSTANCE = inst;
         }
+
+        TRUE_BYTE_VALUE = (byte)INSTANCE.getByte(new boolean[] {true}, BOOLEAN_BASE);
+        FALSE_BYTE_VALUE = (byte)INSTANCE.getByte(new boolean[] {false}, BOOLEAN_BASE);
     }
 
     private UnsafeAccess() {}

--- a/src/main/java/net/openhft/hashing/Util.java
+++ b/src/main/java/net/openhft/hashing/Util.java
@@ -1,0 +1,45 @@
+package net.openhft.hashing;
+
+import org.jetbrains.annotations.NotNull;
+
+import static java.nio.ByteOrder.*;
+
+final class Util {
+    static final boolean NATIVE_LITTLE_ENDIAN = nativeOrder() == LITTLE_ENDIAN;
+
+    @NotNull
+    static final StringHash VALID_STRING_HASH;
+    static  {
+        StringHash stringHash = null;
+        try {
+            if (System.getProperty("java.vm.name").contains("HotSpot")) {
+                final String javaVersion = System.getProperty("java.version");
+                if (javaVersion.compareTo("1.7.0_06") >= 0) {
+                    if (javaVersion.compareTo("1.9") >= 0) {
+                        stringHash = UnknownJvmStringHash.INSTANCE;
+                    } else {
+                        stringHash = ModernHotSpotStringHash.INSTANCE;
+                    }
+                } else {
+                    stringHash = HotSpotPrior7u6StringHash.INSTANCE;
+                }
+            } else {
+                // try to initialize this version anyway
+                stringHash = HotSpotPrior7u6StringHash.INSTANCE;
+            }
+        } catch (final Throwable e) {
+            // ignore
+        } finally {
+            if (null == stringHash) {
+                VALID_STRING_HASH = UnknownJvmStringHash.INSTANCE;
+            } else {
+                VALID_STRING_HASH = stringHash;
+            }
+        }
+    }
+
+    static void checkArrayOffs(final int arrayLength, final int off, final int len) {
+        if (len < 0 || off < 0 || off + len > arrayLength || off + len < 0)
+            throw new IndexOutOfBoundsException();
+    }
+}

--- a/src/main/java/net/openhft/hashing/WyHash.java
+++ b/src/main/java/net/openhft/hashing/WyHash.java
@@ -1,7 +1,7 @@
 package net.openhft.hashing;
 
 import static java.nio.ByteOrder.LITTLE_ENDIAN;
-import static net.openhft.hashing.LongHashFunction.NATIVE_LITTLE_ENDIAN;
+import static net.openhft.hashing.Util.NATIVE_LITTLE_ENDIAN;
 
 /**
  * Adapted version of WyHash implementation from https://github.com/wangyi-fudan/wyhash

--- a/src/main/java/net/openhft/hashing/XxHash.java
+++ b/src/main/java/net/openhft/hashing/XxHash.java
@@ -17,7 +17,7 @@
 package net.openhft.hashing;
 
 import static java.nio.ByteOrder.LITTLE_ENDIAN;
-import static net.openhft.hashing.LongHashFunction.NATIVE_LITTLE_ENDIAN;
+import static net.openhft.hashing.Util.NATIVE_LITTLE_ENDIAN;
 
 /**
  * Adapted version of xxHash implementation from https://github.com/Cyan4973/xxHash.

--- a/src/main/java/net/openhft/hashing/package-info.java
+++ b/src/main/java/net/openhft/hashing/package-info.java
@@ -44,7 +44,7 @@
  *         {@linkplain net.openhft.hashing.LongHashFunction#metro(long) with a seed}.
  *         </li>
  *         <li>
- *         {@linkplain net.openhft.hashing.LongHashFunction#murmur_3() MurmurHash3 without seed} and
+ *         {@linkplain net.openhft.hashing.LongHashFunction#murmur_3() 64-bit MurmurHash3 without seed} and
  *         {@linkplain net.openhft.hashing.LongHashFunction#murmur_3(long) with a seed}.
  *         </li>
  *         <li>
@@ -54,6 +54,21 @@
  *         <li>
  *         {@linkplain net.openhft.hashing.LongHashFunction#xx() xxHash without seed} and
  *         {@linkplain net.openhft.hashing.LongHashFunction#xx(long) with a seed}.
+ *         </li>
+ *     </ul>
+ *     </li>
+ * </ul>
+ *
+ * <p>API for hashing sequential data to more than 64-bit result, pretty fast implementations of
+ * non-cryptographic hash functions.
+ *
+ * <p>Currently implemented (in alphabetical order):
+ * <ul>
+ *     <li>{@code long[]}-valued functions: see {@link net.openhft.hashing.LongTupleHashFunction}
+ *     <ul>
+ *         <li>
+ *         {@linkplain net.openhft.hashing.LongTupleHashFunction#murmur_3() 128-bit MurmurHash3 without seed}
+ *         and {@linkplain net.openhft.hashing.LongTupleHashFunction#murmur_3(long) with a seed}.
  *         </li>
  *     </ul>
  *     </li>

--- a/src/test/java/net/openhft/hashing/LongTupleHashFunctionTest.java
+++ b/src/test/java/net/openhft/hashing/LongTupleHashFunctionTest.java
@@ -11,6 +11,7 @@ import static java.nio.ByteOrder.LITTLE_ENDIAN;
 import static java.nio.ByteOrder.nativeOrder;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.hamcrest.core.IsEqual.equalTo;
@@ -35,21 +36,21 @@ public class LongTupleHashFunctionTest {
         testByteBuffers(f, eh, len, bb);
         testCharSequences(f, eh, len, bb);
         testMemory(f, eh, len, bb);
-
-	LongHashFunctionTest.test(f, data, eh[0]); // test as LongHashFunction
     }
 
     private static void testBits(LongTupleHashFunction f) {
-        assertTrue("bits should be more than 64", f.bits() > 64);
-        assertEquals("tuple length", (f.bits() + 63) / 64, f.newLongTuple().length);
-
-        final int bitsInHighM1 = (f.bits() - 1) & 63;
-        assertEquals("mask should be as default", ((1L << bitsInHighM1) << 1) - 1, f.highMask());
+        assertTrue("bits should be more than 64", f.bitsLength() > 64);
+        assertEquals("tuple length", (f.bitsLength() + 63) / 64, f.newResultArray().length);
     }
 
     private static void testVoid(LongTupleHashFunction f, long[] eh, int len) {
-        if (len == 0)
-            assertArrayEquals("void", eh, f.hashTupleVoid());
+        if (len == 0) {
+            long[] r1 = f.hashVoid();
+            long[] r2 = f.hashVoid();
+            assertNotSame("return different instance", r1, r2);
+            assertArrayEquals("void once", eh, r1);
+            assertArrayEquals("void twice", eh, r2);
+	}
     }
     
     public static void testBoolean(LongTupleHashFunction f, int len) {
@@ -57,33 +58,33 @@ public class LongTupleHashFunctionTest {
             return;
         for (boolean b : new boolean[] {true, false}) {
             boolean[] a = {b};
-            long[] single = f.hashTupleBoolean(b);
-            long[] array = f.hashTupleBooleans(a);
+            long[] single = f.hashBoolean(b);
+            long[] array = f.hashBooleans(a);
             assertArrayEquals(single, array);
-            assertArrayEquals(single, f.hashTuple(a, UnsafeAccess.unsafe(), UnsafeAccess.BOOLEAN_BASE, 1L));
+            assertArrayEquals(single, f.hash(a, UnsafeAccess.unsafe(), UnsafeAccess.BOOLEAN_BASE, 1L));
         }
     }
 
     private static void testPrimitives(LongTupleHashFunction f, long[] eh, int len, ByteBuffer bb) {
         long[] actual;
         if (len == 1) {
-            actual = f.hashTupleByte(bb.get(0));
+            actual = f.hashByte(bb.get(0));
             assertArrayEquals("byte hash", eh, actual);
         }
 
         if (len == 2) {
-            actual = f.hashTupleShort(bb.getShort(0));
+            actual = f.hashShort(bb.getShort(0));
             assertArrayEquals("short hash", eh, actual);
-            actual = f.hashTupleChar(bb.getChar(0));
+            actual = f.hashChar(bb.getChar(0));
             assertArrayEquals("char hash", eh, actual);
         }
 
         if (len == 4) {
-            actual = f.hashTupleInt(bb.getInt(0));
+            actual = f.hashInt(bb.getInt(0));
             assertArrayEquals("int hash", eh, actual);
         }
         if (len == 8) {
-            actual = f.hashTupleLong(bb.getLong(0));
+            actual = f.hashLong(bb.getLong(0));
             assertArrayEquals("long hash", eh, actual);
         }
     }
@@ -91,82 +92,82 @@ public class LongTupleHashFunctionTest {
     private static void testNegativePrimitives(LongTupleHashFunction f) {
         byte[] bytes = new byte[8];
         Arrays.fill(bytes, (byte) -1);
-        long[] oneByteExpected = f.hashTupleBytes(bytes, 0, 1);
-        long[] twoByteExpected = f.hashTupleBytes(bytes, 0, 2);
-        long[] fourByteExpected = f.hashTupleBytes(bytes, 0, 4);
-        long[] eightByteExpected = f.hashTupleBytes(bytes);
-        assertArrayEquals("byte hash", oneByteExpected, f.hashTupleByte((byte) -1));
-        assertArrayEquals("short hash", twoByteExpected, f.hashTupleShort((short) -1));
-        assertArrayEquals("char hash", twoByteExpected, f.hashTupleChar((char) -1));
-        assertArrayEquals("int hash", fourByteExpected, f.hashTupleInt(-1));
-        assertArrayEquals("long hash", eightByteExpected, f.hashTupleLong(-1L));
+        long[] oneByteExpected = f.hashBytes(bytes, 0, 1);
+        long[] twoByteExpected = f.hashBytes(bytes, 0, 2);
+        long[] fourByteExpected = f.hashBytes(bytes, 0, 4);
+        long[] eightByteExpected = f.hashBytes(bytes);
+        assertArrayEquals("byte hash", oneByteExpected, f.hashByte((byte) -1));
+        assertArrayEquals("short hash", twoByteExpected, f.hashShort((short) -1));
+        assertArrayEquals("char hash", twoByteExpected, f.hashChar((char) -1));
+        assertArrayEquals("int hash", fourByteExpected, f.hashInt(-1));
+        assertArrayEquals("long hash", eightByteExpected, f.hashLong(-1L));
     }
 
     private static void testArrays(LongTupleHashFunction f, byte[] data, long[] eh, int len,
                                    ByteBuffer bb) {
-        assertArrayEquals("byte array", eh, f.hashTupleBytes(data));
+        assertArrayEquals("byte array", eh, f.hashBytes(data));
 
         byte[] data2 = new byte[len + 2];
         System.arraycopy(data, 0, data2, 1, len);
-        assertArrayEquals("byte array off len", eh, f.hashTupleBytes(data2, 1, len));
+        assertArrayEquals("byte array off len", eh, f.hashBytes(data2, 1, len));
 
         if ((len & 1) == 0) {
             int shortLen = len / 2;
 
             short[] shorts = new short[shortLen];
             bb.asShortBuffer().get(shorts);
-            assertArrayEquals("short array", eh, f.hashTupleShorts(shorts));
+            assertArrayEquals("short array", eh, f.hashShorts(shorts));
 
             short[] shorts2 = new short[shortLen + 2];
             System.arraycopy(shorts, 0, shorts2, 1, shortLen);
-            assertArrayEquals("short array off len", eh, f.hashTupleShorts(shorts2, 1, shortLen));
+            assertArrayEquals("short array off len", eh, f.hashShorts(shorts2, 1, shortLen));
 
 
             char[] chars = new char[shortLen];
             bb.asCharBuffer().get(chars);
-            assertArrayEquals("char array", eh, f.hashTupleChars(chars));
+            assertArrayEquals("char array", eh, f.hashChars(chars));
 
             char[] chars2 = new char[shortLen + 2];
             System.arraycopy(chars, 0, chars2, 1, shortLen);
-            assertArrayEquals("char array off len", eh, f.hashTupleChars(chars2, 1, shortLen));
+            assertArrayEquals("char array off len", eh, f.hashChars(chars2, 1, shortLen));
         }
 
         if ((len & 3) == 0) {
             int intLen = len / 4;
             int[] ints = new int[intLen];
             bb.asIntBuffer().get(ints);
-            assertArrayEquals("int array", eh, f.hashTupleInts(ints));
+            assertArrayEquals("int array", eh, f.hashInts(ints));
 
             int[] ints2 = new int[intLen + 2];
             System.arraycopy(ints, 0, ints2, 1, intLen);
-            assertArrayEquals("int array off len", eh, f.hashTupleInts(ints2, 1, intLen));
+            assertArrayEquals("int array off len", eh, f.hashInts(ints2, 1, intLen));
         }
 
         if ((len & 7) == 0) {
             int longLen = len / 8;
             long[] longs = new long[longLen];
             bb.asLongBuffer().get(longs);
-            assertArrayEquals("long array", eh, f.hashTupleLongs(longs));
+            assertArrayEquals("long array", eh, f.hashLongs(longs));
 
             long[] longs2 = new long[longLen + 2];
             System.arraycopy(longs, 0, longs2, 1, longLen);
-            assertArrayEquals("long array off len", eh, f.hashTupleLongs(longs2, 1, longLen));
+            assertArrayEquals("long array off len", eh, f.hashLongs(longs2, 1, longLen));
         }
     }
 
     private static void testByteBuffers(LongTupleHashFunction f, long[] eh, int len, ByteBuffer bb) {
         bb.order(LITTLE_ENDIAN);
-        assertArrayEquals("byte buffer little endian", eh, f.hashTupleBytes(bb));
+        assertArrayEquals("byte buffer little endian", eh, f.hashBytes(bb));
         ByteBuffer bb2 = ByteBuffer.allocate(len + 2).order(LITTLE_ENDIAN);
         bb2.position(1);
         bb2.put(bb);
-        assertArrayEquals("byte buffer little endian off len", eh, f.hashTupleBytes(bb2, 1, len));
+        assertArrayEquals("byte buffer little endian off len", eh, f.hashBytes(bb2, 1, len));
 
         bb.order(BIG_ENDIAN).clear();
 
-        assertArrayEquals("byte buffer big endian", eh, f.hashTupleBytes(bb));
+        assertArrayEquals("byte buffer big endian", eh, f.hashBytes(bb));
         bb2.order(BIG_ENDIAN);
-        assertArrayEquals("byte buffer big endian off len", eh, f.hashTupleBytes(bb2, 1, len));
+        assertArrayEquals("byte buffer big endian off len", eh, f.hashBytes(bb2, 1, len));
 
         bb.order(nativeOrder()).clear();
     }
@@ -174,28 +175,28 @@ public class LongTupleHashFunctionTest {
     private static void testCharSequences(LongTupleHashFunction f, long[] eh, int len, ByteBuffer bb) {
         if ((len & 1) == 0) {
             String s = bb.asCharBuffer().toString();
-            assertArrayEquals("string", eh, f.hashTupleChars(s));
+            assertArrayEquals("string", eh, f.hashChars(s));
 
             StringBuilder sb = new StringBuilder();
             sb.append(s);
-            assertArrayEquals("string builder", eh, f.hashTupleChars(sb));
+            assertArrayEquals("string builder", eh, f.hashChars(sb));
 
             sb.insert(0, 'a');
             sb.append('b');
-            assertArrayEquals("string builder off len", eh, f.hashTupleChars(sb, 1, len / 2));
+            assertArrayEquals("string builder off len", eh, f.hashChars(sb, 1, len / 2));
 
             // Test for OpenJDK < 7u6, where substring wasn't copied char[] array
-            assertArrayEquals("substring", eh, f.hashTupleChars(sb.toString().substring(1, len / 2 + 1)));
+            assertArrayEquals("substring", eh, f.hashChars(sb.toString().substring(1, len / 2 + 1)));
 
             if (len >= 2) {
                 bb.order(BIG_ENDIAN);
                 String s2 = bb.asCharBuffer().toString();
                 assert s.charAt(0) != bb.getChar(0);
 
-                long[] hashCharsActual = f.hashTupleChars(s2);
+                long[] hashCharsActual = f.hashChars(s2);
                 assertThat("string wrong order", hashCharsActual, not(equalTo(eh)));
 
-                long[] toCharSequenceActual = f.hashTuple(s2, Access.toCharSequence(nonNativeOrder()), 0, len);
+                long[] toCharSequenceActual = f.hash(s2, Access.toCharSequence(nonNativeOrder()), 0, len);
                 assertArrayEquals("string wrong order fixed", eh, toCharSequenceActual);
 
                 bb.order(nativeOrder()).clear();
@@ -206,7 +207,7 @@ public class LongTupleHashFunctionTest {
     private static void testMemory(LongTupleHashFunction f, long[] eh, int len, ByteBuffer bb) {
         ByteBuffer directBB = ByteBuffer.allocateDirect(len);
         directBB.put(bb);
-        assertArrayEquals("memory", eh, f.hashTupleMemory(((DirectBuffer) directBB).address(), len));
+        assertArrayEquals("memory", eh, f.hashMemory(((DirectBuffer) directBB).address(), len));
         bb.clear();
     }
 }

--- a/src/test/java/net/openhft/hashing/LongTupleHashFunctionTest.java
+++ b/src/test/java/net/openhft/hashing/LongTupleHashFunctionTest.java
@@ -53,8 +53,8 @@ public class LongTupleHashFunctionTest {
         boolean ok = false;
         try {
             f.hashBytes(new byte[0], null);
-        } catch (NullPointerException e) {
-            ok = true; // expected
+        } catch (NullPointerException expected) {
+            ok = true;
         } catch (Throwable e) {
             fail(e.toString());
         }
@@ -63,12 +63,12 @@ public class LongTupleHashFunctionTest {
         ok = false;
         try {
             f.hashBytes(new byte[0], new long[1]);
-        } catch (IndexOutOfBoundsException e) {
-            ok = true; // expected
+        } catch (IllegalArgumentException expected) {
+            ok = true;
         } catch (Throwable e) {
             fail(e.toString());
         }
-        assertTrue("should throw IndexOutOfBoundsException", ok);
+        assertTrue("should throw IllegalArgumentException", ok);
 
         // no exception with larger array
         long[] r1 = f.hashBytes(new byte[1]);

--- a/src/test/java/net/openhft/hashing/LongTupleHashFunctionTest.java
+++ b/src/test/java/net/openhft/hashing/LongTupleHashFunctionTest.java
@@ -41,6 +41,7 @@ public class LongTupleHashFunctionTest {
     private static void testBits(LongTupleHashFunction f) {
         assertTrue("bits should be more than 64", f.bitsLength() > 64);
         assertEquals("tuple length", (f.bitsLength() + 63) / 64, f.newResultArray().length);
+        assertTrue("mutiple of 8", f.bitsLength() % 8 == 0);
     }
 
     private static void testVoid(LongTupleHashFunction f, long[] eh, int len) {

--- a/src/test/java/net/openhft/hashing/LongTupleHashFunctionTest.java
+++ b/src/test/java/net/openhft/hashing/LongTupleHashFunctionTest.java
@@ -1,0 +1,212 @@
+package net.openhft.hashing;
+
+import sun.nio.ch.DirectBuffer;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.Arrays;
+
+import static java.nio.ByteOrder.BIG_ENDIAN;
+import static java.nio.ByteOrder.LITTLE_ENDIAN;
+import static java.nio.ByteOrder.nativeOrder;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.hamcrest.core.IsNot.not;
+
+public class LongTupleHashFunctionTest {
+
+    private static ByteOrder nonNativeOrder() {
+        return nativeOrder() == LITTLE_ENDIAN ? BIG_ENDIAN : LITTLE_ENDIAN;
+    }
+
+    public static void test(LongTupleHashFunction f, byte[] data, long[] eh) {
+        testBits(f);
+
+        int len = data.length;
+        testVoid(f, eh, len);
+        testBoolean(f, len);
+        ByteBuffer bb = ByteBuffer.wrap(data).order(nativeOrder());
+        testPrimitives(f, eh, len, bb);
+        testNegativePrimitives(f);
+        testArrays(f, data, eh, len, bb);
+        testByteBuffers(f, eh, len, bb);
+        testCharSequences(f, eh, len, bb);
+        testMemory(f, eh, len, bb);
+
+	LongHashFunctionTest.test(f, data, eh[0]); // test as LongHashFunction
+    }
+
+    private static void testBits(LongTupleHashFunction f) {
+        assertTrue("bits should be more than 64", f.bits() > 64);
+        assertEquals("tuple length", (f.bits() + 63) / 64, f.newLongTuple().length);
+
+        final int bitsInHighM1 = (f.bits() - 1) & 63;
+        assertEquals("mask should be as default", ((1L << bitsInHighM1) << 1) - 1, f.highMask());
+    }
+
+    private static void testVoid(LongTupleHashFunction f, long[] eh, int len) {
+        if (len == 0)
+            assertArrayEquals("void", eh, f.hashTupleVoid());
+    }
+    
+    public static void testBoolean(LongTupleHashFunction f, int len) {
+        if (len != 1)
+            return;
+        for (boolean b : new boolean[] {true, false}) {
+            boolean[] a = {b};
+            long[] single = f.hashTupleBoolean(b);
+            long[] array = f.hashTupleBooleans(a);
+            assertArrayEquals(single, array);
+            assertArrayEquals(single, f.hashTuple(a, UnsafeAccess.unsafe(), UnsafeAccess.BOOLEAN_BASE, 1L));
+        }
+    }
+
+    private static void testPrimitives(LongTupleHashFunction f, long[] eh, int len, ByteBuffer bb) {
+        long[] actual;
+        if (len == 1) {
+            actual = f.hashTupleByte(bb.get(0));
+            assertArrayEquals("byte hash", eh, actual);
+        }
+
+        if (len == 2) {
+            actual = f.hashTupleShort(bb.getShort(0));
+            assertArrayEquals("short hash", eh, actual);
+            actual = f.hashTupleChar(bb.getChar(0));
+            assertArrayEquals("char hash", eh, actual);
+        }
+
+        if (len == 4) {
+            actual = f.hashTupleInt(bb.getInt(0));
+            assertArrayEquals("int hash", eh, actual);
+        }
+        if (len == 8) {
+            actual = f.hashTupleLong(bb.getLong(0));
+            assertArrayEquals("long hash", eh, actual);
+        }
+    }
+
+    private static void testNegativePrimitives(LongTupleHashFunction f) {
+        byte[] bytes = new byte[8];
+        Arrays.fill(bytes, (byte) -1);
+        long[] oneByteExpected = f.hashTupleBytes(bytes, 0, 1);
+        long[] twoByteExpected = f.hashTupleBytes(bytes, 0, 2);
+        long[] fourByteExpected = f.hashTupleBytes(bytes, 0, 4);
+        long[] eightByteExpected = f.hashTupleBytes(bytes);
+        assertArrayEquals("byte hash", oneByteExpected, f.hashTupleByte((byte) -1));
+        assertArrayEquals("short hash", twoByteExpected, f.hashTupleShort((short) -1));
+        assertArrayEquals("char hash", twoByteExpected, f.hashTupleChar((char) -1));
+        assertArrayEquals("int hash", fourByteExpected, f.hashTupleInt(-1));
+        assertArrayEquals("long hash", eightByteExpected, f.hashTupleLong(-1L));
+    }
+
+    private static void testArrays(LongTupleHashFunction f, byte[] data, long[] eh, int len,
+                                   ByteBuffer bb) {
+        assertArrayEquals("byte array", eh, f.hashTupleBytes(data));
+
+        byte[] data2 = new byte[len + 2];
+        System.arraycopy(data, 0, data2, 1, len);
+        assertArrayEquals("byte array off len", eh, f.hashTupleBytes(data2, 1, len));
+
+        if ((len & 1) == 0) {
+            int shortLen = len / 2;
+
+            short[] shorts = new short[shortLen];
+            bb.asShortBuffer().get(shorts);
+            assertArrayEquals("short array", eh, f.hashTupleShorts(shorts));
+
+            short[] shorts2 = new short[shortLen + 2];
+            System.arraycopy(shorts, 0, shorts2, 1, shortLen);
+            assertArrayEquals("short array off len", eh, f.hashTupleShorts(shorts2, 1, shortLen));
+
+
+            char[] chars = new char[shortLen];
+            bb.asCharBuffer().get(chars);
+            assertArrayEquals("char array", eh, f.hashTupleChars(chars));
+
+            char[] chars2 = new char[shortLen + 2];
+            System.arraycopy(chars, 0, chars2, 1, shortLen);
+            assertArrayEquals("char array off len", eh, f.hashTupleChars(chars2, 1, shortLen));
+        }
+
+        if ((len & 3) == 0) {
+            int intLen = len / 4;
+            int[] ints = new int[intLen];
+            bb.asIntBuffer().get(ints);
+            assertArrayEquals("int array", eh, f.hashTupleInts(ints));
+
+            int[] ints2 = new int[intLen + 2];
+            System.arraycopy(ints, 0, ints2, 1, intLen);
+            assertArrayEquals("int array off len", eh, f.hashTupleInts(ints2, 1, intLen));
+        }
+
+        if ((len & 7) == 0) {
+            int longLen = len / 8;
+            long[] longs = new long[longLen];
+            bb.asLongBuffer().get(longs);
+            assertArrayEquals("long array", eh, f.hashTupleLongs(longs));
+
+            long[] longs2 = new long[longLen + 2];
+            System.arraycopy(longs, 0, longs2, 1, longLen);
+            assertArrayEquals("long array off len", eh, f.hashTupleLongs(longs2, 1, longLen));
+        }
+    }
+
+    private static void testByteBuffers(LongTupleHashFunction f, long[] eh, int len, ByteBuffer bb) {
+        bb.order(LITTLE_ENDIAN);
+        assertArrayEquals("byte buffer little endian", eh, f.hashTupleBytes(bb));
+        ByteBuffer bb2 = ByteBuffer.allocate(len + 2).order(LITTLE_ENDIAN);
+        bb2.position(1);
+        bb2.put(bb);
+        assertArrayEquals("byte buffer little endian off len", eh, f.hashTupleBytes(bb2, 1, len));
+
+        bb.order(BIG_ENDIAN).clear();
+
+        assertArrayEquals("byte buffer big endian", eh, f.hashTupleBytes(bb));
+        bb2.order(BIG_ENDIAN);
+        assertArrayEquals("byte buffer big endian off len", eh, f.hashTupleBytes(bb2, 1, len));
+
+        bb.order(nativeOrder()).clear();
+    }
+
+    private static void testCharSequences(LongTupleHashFunction f, long[] eh, int len, ByteBuffer bb) {
+        if ((len & 1) == 0) {
+            String s = bb.asCharBuffer().toString();
+            assertArrayEquals("string", eh, f.hashTupleChars(s));
+
+            StringBuilder sb = new StringBuilder();
+            sb.append(s);
+            assertArrayEquals("string builder", eh, f.hashTupleChars(sb));
+
+            sb.insert(0, 'a');
+            sb.append('b');
+            assertArrayEquals("string builder off len", eh, f.hashTupleChars(sb, 1, len / 2));
+
+            // Test for OpenJDK < 7u6, where substring wasn't copied char[] array
+            assertArrayEquals("substring", eh, f.hashTupleChars(sb.toString().substring(1, len / 2 + 1)));
+
+            if (len >= 2) {
+                bb.order(BIG_ENDIAN);
+                String s2 = bb.asCharBuffer().toString();
+                assert s.charAt(0) != bb.getChar(0);
+
+                long[] hashCharsActual = f.hashTupleChars(s2);
+                assertThat("string wrong order", hashCharsActual, not(equalTo(eh)));
+
+                long[] toCharSequenceActual = f.hashTuple(s2, Access.toCharSequence(nonNativeOrder()), 0, len);
+                assertArrayEquals("string wrong order fixed", eh, toCharSequenceActual);
+
+                bb.order(nativeOrder()).clear();
+            }
+        }
+    }
+
+    private static void testMemory(LongTupleHashFunction f, long[] eh, int len, ByteBuffer bb) {
+        ByteBuffer directBB = ByteBuffer.allocateDirect(len);
+        directBB.put(bb);
+        assertArrayEquals("memory", eh, f.hashTupleMemory(((DirectBuffer) directBB).address(), len));
+        bb.clear();
+    }
+}

--- a/src/test/java/net/openhft/hashing/MurmurHash3Test.java
+++ b/src/test/java/net/openhft/hashing/MurmurHash3Test.java
@@ -30,15 +30,15 @@ public class MurmurHash3Test {
 
     @Test
     public void testMurmurWithoutSeed() {
-        testMurmur(LongTupleHashFunction.murmur_3(), Hashing.murmur3_128());
+        testMurmur(LongTupleHashFunction.murmur_3(), LongHashFunction.murmur_3(), Hashing.murmur3_128());
     }
 
     @Test
     public void testMurmurWithSeed() {
-        testMurmur(LongTupleHashFunction.murmur_3(42L), Hashing.murmur3_128(42));
+        testMurmur(LongTupleHashFunction.murmur_3(42L), LongHashFunction.murmur_3(42L), Hashing.murmur3_128(42));
     }
 
-    private void testMurmur(LongTupleHashFunction tested, HashFunction referenceFromGuava) {
+    private void testMurmur(LongTupleHashFunction tested, LongHashFunction tested2, HashFunction referenceFromGuava) {
         byte[] testData = new byte[1024];
         for (int i = 0; i < testData.length; i++) {
             testData[i] = (byte) i;
@@ -48,7 +48,10 @@ public class MurmurHash3Test {
             byte[] ehBytes = referenceFromGuava.hashBytes(data).asBytes();
             long[] eh = new long[(ehBytes.length + 7) / 8];
             ByteBuffer.wrap(ehBytes).order(ByteOrder.LITTLE_ENDIAN).asLongBuffer().get(eh);
+
             LongTupleHashFunctionTest.test(tested, data, eh);
+
+            LongHashFunctionTest.test(tested2, data, eh[0]); // test as LongHashFunction
         }
     }
 }

--- a/src/test/java/net/openhft/hashing/MurmurHash3Test.java
+++ b/src/test/java/net/openhft/hashing/MurmurHash3Test.java
@@ -23,27 +23,32 @@ import org.junit.Test;
 
 import java.util.Arrays;
 import java.util.Random;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 
 public class MurmurHash3Test {
 
     @Test
     public void testMurmurWithoutSeed() {
-        testMurmur(LongHashFunction.murmur_3(), Hashing.murmur3_128());
+        testMurmur(LongTupleHashFunction.murmur_3(), Hashing.murmur3_128());
     }
 
     @Test
     public void testMurmurWithSeed() {
-        testMurmur(LongHashFunction.murmur_3(42L), Hashing.murmur3_128(42));
+        testMurmur(LongTupleHashFunction.murmur_3(42L), Hashing.murmur3_128(42));
     }
 
-    private void testMurmur(LongHashFunction tested, HashFunction referenceFromGuava) {
+    private void testMurmur(LongTupleHashFunction tested, HashFunction referenceFromGuava) {
         byte[] testData = new byte[1024];
         for (int i = 0; i < testData.length; i++) {
             testData[i] = (byte) i;
         }
         for (int i = 0; i < testData.length; i++) {
             byte[] data = Arrays.copyOf(testData, i);
-            LongHashFunctionTest.test(tested, data, referenceFromGuava.hashBytes(data).asLong());
+            byte[] ehBytes = referenceFromGuava.hashBytes(data).asBytes();
+            long[] eh = new long[(ehBytes.length + 7) / 8];
+            ByteBuffer.wrap(ehBytes).order(ByteOrder.LITTLE_ENDIAN).asLongBuffer().get(eh);
+            LongTupleHashFunctionTest.test(tested, data, eh);
         }
     }
 }


### PR DESCRIPTION
Add an interface `LongTupleHashFunction` which extends the 64-bit `LongHashFunction`. The new interface add two sets of APIs while keeping compatible to the original long API:

1. `long hash(..., long[] result);`
2. `long[] hashTuple(...);`

Among three sets of the hash API, the real work will appear in the `long hash(..., long[] result)` style functions which should returns `result[0]` as the direct result. The other sets can be deduced from this style ones.

In the mean time, the implementation of `LongTupleHashFunction` must override `bits()` function providing the real bits of this function. The result of `bits()` should be larger than 64, but don't have to be divided by 64.

I choose `long[]` for the result container since it is very simple and can be optimized by JIT. When developing a `long hash(..., long[] result)`, we just need to check if the `result` is `null`, which means omitting the full result, and don't have to check`result.length()`. `LongTupleHashFunction` provides a `newLongTuple()` function to alloc a correct array based on `bits()`.

Since a result container can be easily reused within one thread, so the cost of allocation could trend to zero.

Murmur3F 128-bit has been migrated to `LongTupleHashFunction'.