### PR TITLE
UnsafeAccess supports jre w/o Unsafe.getByte, e.g. Android API 19-23

### DIFF
--- a/src/main/java/net/openhft/hashing/UnsafeAccess.java
+++ b/src/main/java/net/openhft/hashing/UnsafeAccess.java
@@ -119,7 +119,7 @@ class UnsafeAccess extends Access<Object> {
     private static class OldUnsafeAccessBigEndian extends UnsafeAccess {
         @Override
         public int getShort(final Object input, final long offset) {
-            return (int)(short)UNSAFE.getInt(input, offset -2);
+            return (int)(short)UNSAFE.getInt(input, offset - 2);
         }
 
         @Override

--- a/src/main/java/net/openhft/hashing/UnsafeAccess.java
+++ b/src/main/java/net/openhft/hashing/UnsafeAccess.java
@@ -23,8 +23,11 @@ import java.nio.ByteOrder;
 
 import static net.openhft.hashing.Primitives.*;
 
-final class UnsafeAccess extends Access<Object> {
-    public static final UnsafeAccess INSTANCE = new UnsafeAccess();
+class UnsafeAccess extends Access<Object> {
+    public static final UnsafeAccess INSTANCE;
+    static final UnsafeAccess OLD_INSTANCE = ByteOrder.nativeOrder() == ByteOrder.LITTLE_ENDIAN
+                                             ? new OldUnsafeAccessLittleEndian()
+                                             : new OldUnsafeAccessBigEndian();
 
     static final Unsafe UNSAFE;
     static final long BOOLEAN_BASE;
@@ -47,6 +50,15 @@ final class UnsafeAccess extends Access<Object> {
             LONG_BASE = UNSAFE.arrayBaseOffset(long[].class);
         } catch (Exception e) {
             throw new AssertionError(e);
+        }
+
+        UnsafeAccess inst = new UnsafeAccess();
+        try {
+            inst.getByte(new byte[1], BYTE_BASE);
+        } catch (final Throwable e) {
+            inst = OLD_INSTANCE;
+        } finally {
+            INSTANCE = inst;
         }
     }
 
@@ -92,4 +104,27 @@ final class UnsafeAccess extends Access<Object> {
         return ByteOrder.nativeOrder();
     }
 
+    private static class OldUnsafeAccessLittleEndian extends UnsafeAccess {
+        @Override
+        public int getShort(final Object input, final long offset) {
+            return UNSAFE.getInt(input, offset - 2) >> 16;
+        }
+
+        @Override
+        public int getByte(final Object input, final long offset) {
+            return UNSAFE.getInt(input, offset - 3) >> 24;
+        }
+    }
+
+    private static class OldUnsafeAccessBigEndian extends UnsafeAccess {
+        @Override
+        public int getShort(final Object input, final long offset) {
+            return (int)(short)UNSAFE.getInt(input, offset -2);
+        }
+
+        @Override
+        public int getByte(final Object input, final long offset) {
+            return (int)(byte)UNSAFE.getInt(input, offset - 3);
+        }
+    }
 }

--- a/src/test/java/net/openhft/hashing/UnsafeAccessTest.java
+++ b/src/test/java/net/openhft/hashing/UnsafeAccessTest.java
@@ -1,0 +1,46 @@
+package net.openhft.hashing;
+
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
+
+public class UnsafeAccessTest {
+    @Test
+    public void test() {
+        assertNotSame("compile with jdk with Unsafe.getByte()", UnsafeAccess.INSTANCE, UnsafeAccess.OLD_INSTANCE);
+        testUnsafeAccess(UnsafeAccess.INSTANCE);
+        testUnsafeAccess(UnsafeAccess.OLD_INSTANCE);
+    }
+
+    private static void testUnsafeAccess(final Access<Object> unsafe) {
+        {
+            final long[] l = new long[]{0xFEDCBA9876543210L, 0x123456789ABCDEFL};
+            assertEquals(l[0], unsafe.getLong(l, UnsafeAccess.LONG_BASE));
+            assertEquals(l[1], unsafe.getLong(l, UnsafeAccess.LONG_BASE + 8));
+        }
+
+        {
+            final int[] i = new int[]{0xFEDCBA98, 0x1234567};
+            assertEquals(i[0], unsafe.getInt(i, UnsafeAccess.INT_BASE));
+            assertEquals(i[1], unsafe.getInt(i, UnsafeAccess.INT_BASE + 4));
+            assertEquals(Primitives.unsignedInt(i[0]), unsafe.getUnsignedInt(i, UnsafeAccess.INT_BASE));
+            assertEquals(Primitives.unsignedInt(i[1]), unsafe.getUnsignedInt(i, UnsafeAccess.INT_BASE + 4));
+        }
+
+        {
+            final short[] s = new short[]{(short) 0xF466, 0x227A};
+            assertEquals((int) s[0], unsafe.getShort(s, UnsafeAccess.SHORT_BASE));
+            assertEquals((int) s[1], unsafe.getShort(s, UnsafeAccess.SHORT_BASE + 2));
+            assertEquals(Primitives.unsignedShort(s[0]), unsafe.getUnsignedShort(s, UnsafeAccess.SHORT_BASE));
+            assertEquals(Primitives.unsignedShort(s[1]), unsafe.getUnsignedShort(s, UnsafeAccess.SHORT_BASE + 2));
+        }
+
+        {
+            final byte[] b = new byte[]{(byte)0xF4, 0x5D};
+            assertEquals((int) b[0], unsafe.getByte(b, UnsafeAccess.BYTE_BASE));
+            assertEquals((int) b[1], unsafe.getByte(b, UnsafeAccess.BYTE_BASE + 1));
+            assertEquals(Primitives.unsignedByte(b[0]), unsafe.getUnsignedByte(b, UnsafeAccess.BYTE_BASE));
+            assertEquals(Primitives.unsignedByte(b[1]), unsafe.getUnsignedByte(b, UnsafeAccess.BYTE_BASE + 1));
+        }
+    }
+}


### PR DESCRIPTION
On some old java runtime, e.g. in Android API level 19~23, the class `Unsafe` has no `getByte()` nor `getShort()` methods. In this case, we can indirectly get results by `getInt()` to first read a larger piece of memory.

When calculating hash, we do not read from the Java object headers, so `getInt(o, offset - 3)` is safe.

Fix #33 .