### PR TITLE
CharSequenceAccess supports unalign offsets

### DIFF
--- a/src/main/java/net/openhft/hashing/CharSequenceAccess.java
+++ b/src/main/java/net/openhft/hashing/CharSequenceAccess.java
@@ -67,7 +67,7 @@ abstract class CharSequenceAccess extends Access<CharSequence> {
         } else {
             final long char0 = input.charAt(base + char0Off + delta) >>> 8;
             final long char1 = input.charAt(base + char1Off + delta);
-            final int char2 = input.charAt(base + char2Off);
+            final long char2 = Primitives.unsignedByte(input.charAt(base + char2Off));
             return char0 | (char1 << 8) | (char2 << 24);
         }
     }

--- a/src/main/java/net/openhft/hashing/CharSequenceAccess.java
+++ b/src/main/java/net/openhft/hashing/CharSequenceAccess.java
@@ -39,20 +39,37 @@ abstract class CharSequenceAccess extends Access<CharSequence> {
 
     static long getLong(CharSequence input, long offset,
                         int char0Off, int char1Off, int char2Off, int char3Off) {
-        int base = ix(offset);
-        long char0 = input.charAt(base + char0Off);
-        long char1 = input.charAt(base + char1Off);
-        long char2 = input.charAt(base + char2Off);
-        long char3 = input.charAt(base + char3Off);
-        return char0 | (char1 << 16) | (char2 << 32) | (char3 << 48);
+        final int base = ix(offset);
+        if (0 == ((int)offset & 1)) {
+            final long char0 = input.charAt(base + char0Off);
+            final long char1 = input.charAt(base + char1Off);
+            final long char2 = input.charAt(base + char2Off);
+            final long char3 = input.charAt(base + char3Off);
+            return char0 | (char1 << 16) | (char2 << 32) | (char3 << 48);
+        } else {
+            final int delta = char0Off & 1;
+            final long char0 = input.charAt(base + char0Off + delta) >>> 8;
+            final long char1 = input.charAt(base + char1Off + delta);
+            final long char2 = input.charAt(base + char2Off + delta);
+            final long char3 = input.charAt(base + char3Off + delta);
+            final long char4 = input.charAt(base + ((delta ^ 1) << 2));
+            return char0 | (char1 << 8) | (char2 << 24) | (char3 << 40) | (char4 << 56);
+        }
     }
 
-    static long getUnsignedInt(CharSequence input, long offset,
-                               int char0Off, int char1Off) {
-        int base = ix(offset);
-        long char0 = input.charAt(base + char0Off);
-        long char1 = input.charAt(base + char1Off);
-        return char0 | (char1 << 16);
+    static long getUnsignedInt(CharSequence input, long offset, int char0Off, int char1Off) {
+        final int base = ix(offset);
+        if (0 == ((int)offset & 1)) {
+            final long char0 = input.charAt(base + char0Off);
+            final long char1 = input.charAt(base + char1Off);
+            return char0 | (char1 << 16);
+        } else {
+            final int delta = char0Off & 1;
+            final long char0 = input.charAt(base + char0Off + delta) >>> 8;
+            final long char1 = input.charAt(base + char1Off + delta);
+            final long char2 = Primitives.unsignedByte(input.charAt(base + ((delta ^ 1) << 1)));
+            return char0 | (char1 << 8) | (char2 << 24);
+        }
     }
 
     private CharSequenceAccess() {}
@@ -64,12 +81,26 @@ abstract class CharSequenceAccess extends Access<CharSequence> {
 
     @Override
     public int getUnsignedShort(CharSequence input, long offset) {
-        return input.charAt(ix(offset));
+        if (((int)offset & 1) == 0) {
+            return input.charAt(ix(offset));
+        } else {
+            final int base = ix(offset);
+            final int char0 = input.charAt(base) >>> 8;
+            final int char1 = input.charAt(base + 1);
+            return char0 | (char1 << 8);
+        }
     }
 
     @Override
     public int getShort(CharSequence input, long offset) {
-        return (int) (short) input.charAt(ix(offset));
+        if (((int)offset & 1) == 0) {
+            return (int) (short) input.charAt(ix(offset));
+        } else {
+            final int base = ix(offset);
+            final int char0 = input.charAt(base) >>> 8;
+            final int char1 = (int)(byte)input.charAt(base + 1);
+            return char0 | (char1 << 8);
+        }
     }
 
     static int getUnsignedByte(CharSequence input, long offset, int shift) {
@@ -120,6 +151,30 @@ abstract class CharSequenceAccess extends Access<CharSequence> {
         @Override
         public long getUnsignedInt(CharSequence input, long offset) {
             return getUnsignedInt(input, offset, 1, 0);
+        }
+
+        @Override
+        public int getUnsignedShort(CharSequence input, long offset) {
+            if (((int)offset & 1) == 0) {
+                return input.charAt(ix(offset));
+            } else {
+                final int base = ix(offset);
+                final int char0 = input.charAt(base + 1) >>> 8;
+                final int char1 = Primitives.unsignedByte(input.charAt(base));
+                return char0 | (char1 << 8);
+            }
+        }
+
+        @Override
+        public int getShort(CharSequence input, long offset) {
+            if (((int)offset & 1) == 0) {
+                return (int) (short) input.charAt(ix(offset));
+            } else {
+                final int base = ix(offset);
+                final int char0 = input.charAt(base + 1) >>> 8;
+                final int char1 = (int)(byte)input.charAt(base);
+                return char0 | (char1 << 8);
+            }
         }
 
         @Override

--- a/src/test/java/net/openhft/hashing/CharSequenceAccessTest.java
+++ b/src/test/java/net/openhft/hashing/CharSequenceAccessTest.java
@@ -8,61 +8,61 @@ import static java.nio.ByteOrder.*;
 import static net.openhft.hashing.Primitives.*;
 
 public class CharSequenceAccessTest {
-    static String TEST_STRING = "ABCDEFGH";
-
-    static long buildNumber(char ll, char lh, char hl, char hh) {
-        return ll | (((int)lh) << 16) | (((long)hl) << 32) | (((long)hh) << 48);
-    }
+    static String TEST_STRING2 = new String(new char[] {0xF0E1,0xD2C3,0xB4A5,0x9687,0xC8E9});
 
     @Test
     public void testLittleEndian() {
-        assertEquals(LITTLE_ENDIAN, nativeOrder()); // ut is designed for LE machines
+        if (LITTLE_ENDIAN != nativeOrder()) {
+            return; // ut is designed for LE machines
+        }
 
         final Access<CharSequence> access = CharSequenceAccess.charSequenceAccess(LITTLE_ENDIAN);
         assertSame(CharSequenceAccess.nativeCharSequenceAccess(), access);
 
-        assertEquals(buildNumber('A', 'B', 'C', 'D'), access.getLong(TEST_STRING, 0));
-        assertEquals((buildNumber('A', 'B', 'C', 'D') >>> 8) | (((long)'E') << 56), access.getLong(TEST_STRING, 1));
+        assertEquals(  0x9687B4A5D2C3F0E1L, access.getLong(TEST_STRING2, 0));
+        assertEquals(0xE99687B4A5D2C3F0L  , access.getLong(TEST_STRING2, 1));
 
-        assertEquals((int)buildNumber('A', 'B', '\0', '\0'), access.getInt(TEST_STRING, 0));
-        assertEquals((int)(buildNumber('A', 'B', 'C', '\0') >>> 8), access.getInt(TEST_STRING, 1));
-        assertEquals(unsignedInt((int)buildNumber('A', 'B', '\0', '\0')), access.getUnsignedInt(TEST_STRING, 0));
-        assertEquals(unsignedInt((int)(buildNumber('A', 'B', 'C', '\0') >>> 8)), access.getUnsignedInt(TEST_STRING, 1));
+        assertEquals(unsignedInt(  0xD2C3F0E1), access.getUnsignedInt(TEST_STRING2, 0));
+        assertEquals(unsignedInt(0xA5D2C3F0  ), access.getUnsignedInt(TEST_STRING2, 1));
+        assertEquals(  0xD2C3F0E1, access.getInt(TEST_STRING2, 0));
+        assertEquals(0xA5D2C3F0  , access.getInt(TEST_STRING2, 1));
 
-        assertEquals((int)buildNumber('A', '\0', '\0', '\0'), access.getShort(TEST_STRING, 0));
-        assertEquals((int)(short)(buildNumber('A', 'B', '\0', '\0') >>> 8), access.getShort(TEST_STRING, 1));
-        assertEquals(unsignedShort((short)buildNumber('A', '\0', '\0', '\0')), access.getUnsignedShort(TEST_STRING, 0));
-        assertEquals(unsignedShort((short)(buildNumber('A', 'B', '\0', '\0') >>> 8)), access.getUnsignedShort(TEST_STRING, 1));
+        assertEquals(unsignedShort(  0xF0E1), access.getUnsignedShort(TEST_STRING2, 0));
+        assertEquals(unsignedShort(0xC3F0  ), access.getUnsignedShort(TEST_STRING2, 1));
+        assertEquals((int)(short)  0xF0E1, access.getShort(TEST_STRING2, 0));
+        assertEquals((int)(short)0xC3F0  , access.getShort(TEST_STRING2, 1));
 
-        assertEquals((int)(byte)buildNumber('A', '\0', '\0', '\0'), access.getByte(TEST_STRING, 0));
-        assertEquals((int)(byte)(buildNumber('A', '\0', '\0', '\0') >>> 8), access.getByte(TEST_STRING, 1));
-        assertEquals(unsignedByte((byte)buildNumber('A', '\0', '\0', '\0')), access.getUnsignedByte(TEST_STRING, 0));
-        assertEquals(unsignedByte((byte)(buildNumber('A', '\0', '\0', '\0') >>> 8)), access.getUnsignedByte(TEST_STRING, 1));
+        assertEquals(unsignedByte(0xE1), access.getUnsignedByte(TEST_STRING2, 0));
+        assertEquals(unsignedByte(0xF0), access.getUnsignedByte(TEST_STRING2, 1));
+        assertEquals((int)(byte)0xE1, access.getByte(TEST_STRING2, 0));
+        assertEquals((int)(byte)0xF0, access.getByte(TEST_STRING2, 1));
     }
 
     @Test
-    public void testBigEndian() {
-        assertEquals(LITTLE_ENDIAN, nativeOrder()); // ut is designed for LE machines
+    public void testBigEndianOnLEMachine() {
+        if (LITTLE_ENDIAN != nativeOrder()) {
+            return; // ut is designed for LE machines
+        }
 
         final Access<CharSequence> access = CharSequenceAccess.charSequenceAccess(BIG_ENDIAN);
         assertNotSame(CharSequenceAccess.nativeCharSequenceAccess(), access);
 
-        assertEquals(buildNumber('D', 'C', 'B', 'A'), access.getLong(TEST_STRING, 0));
-        assertEquals((buildNumber('D', 'C', 'B', 'A') << 8) | ((byte)('E'>>>8)), access.getLong(TEST_STRING, 1));
+        assertEquals(0xF0E1D2C3B4A59687L  , access.getLong(TEST_STRING2, 0));
+        assertEquals(  0xE1D2C3B4A59687C8L, access.getLong(TEST_STRING2, 1));
 
-        assertEquals((int)buildNumber('B', 'A', '\0', '\0'), access.getInt(TEST_STRING, 0));
-        assertEquals((int)(buildNumber((char)('C'>>>8), 'B', 'A', '\0') >>> 8), access.getInt(TEST_STRING, 1));
-        assertEquals(unsignedInt((int)buildNumber('B', 'A', '\0', '\0')), access.getUnsignedInt(TEST_STRING, 0));
-        assertEquals(unsignedInt((int)(buildNumber((char)('C'>>>8), 'B', 'A', '\0') >>> 8)), access.getUnsignedInt(TEST_STRING, 1));
+        assertEquals(unsignedInt(0xF0E1D2C3), access.getUnsignedInt(TEST_STRING2, 0));
+        assertEquals(unsignedInt(  0xE1D2C3B4), access.getUnsignedInt(TEST_STRING2, 1));
+        assertEquals(0xF0E1D2C3, access.getInt(TEST_STRING2, 0));
+        assertEquals(  0xE1D2C3B4, access.getInt(TEST_STRING2, 1));
 
-        assertEquals((int)buildNumber('A', '\0', '\0', '\0'), access.getShort(TEST_STRING, 0));
-        assertEquals((int)(short)(buildNumber((char)('B'>>>8), 'A', '\0', '\0') >>> 8), access.getShort(TEST_STRING, 1));
-        assertEquals(unsignedShort((short)buildNumber('A', '\0', '\0', '\0')), access.getUnsignedShort(TEST_STRING, 0));
-        assertEquals(unsignedShort((short)(buildNumber((char)('B'>>>8), 'A', '\0', '\0') >>> 8)), access.getUnsignedShort(TEST_STRING, 1));
+        assertEquals(unsignedShort(0xF0E1), access.getUnsignedShort(TEST_STRING2, 0));
+        assertEquals(unsignedShort(  0xE1D2), access.getUnsignedShort(TEST_STRING2, 1));
+        assertEquals((int)(short)0xF0E1, access.getShort(TEST_STRING2, 0));
+        assertEquals((int)(short)  0xE1D2, access.getShort(TEST_STRING2, 1));
 
-        assertEquals((int)(byte)(buildNumber('A', '\0', '\0', '\0') >> 8), access.getByte(TEST_STRING, 0));
-        assertEquals((int)(byte)buildNumber('A', '\0', '\0', '\0'), access.getByte(TEST_STRING, 1));
-        assertEquals(unsignedByte((byte)(buildNumber('A', '\0', '\0', '\0') >> 8)), access.getUnsignedByte(TEST_STRING, 0));
-        assertEquals(unsignedByte((byte)buildNumber('A', '\0', '\0', '\0')), access.getUnsignedByte(TEST_STRING, 1));
+        assertEquals(unsignedByte(0xF0), access.getUnsignedByte(TEST_STRING2, 0));
+        assertEquals(unsignedByte(0xE1), access.getUnsignedByte(TEST_STRING2, 1));
+        assertEquals((int)(byte)0xF0, access.getByte(TEST_STRING2, 0));
+        assertEquals((int)(byte)0xE1, access.getByte(TEST_STRING2, 1));
     }
 }

--- a/src/test/java/net/openhft/hashing/CharSequenceAccessTest.java
+++ b/src/test/java/net/openhft/hashing/CharSequenceAccessTest.java
@@ -1,0 +1,68 @@
+package net.openhft.hashing;
+
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+import static java.nio.ByteOrder.*;
+import static net.openhft.hashing.Primitives.*;
+
+public class CharSequenceAccessTest {
+    static String TEST_STRING = "ABCDEFGH";
+
+    static long buildNumber(char ll, char lh, char hl, char hh) {
+        return unsignedShort(ll) | (unsignedShort(lh) << 16) | (((long)unsignedShort(hl)) << 32) | (((long)unsignedShort(hh)) << 48);
+    }
+
+    @Test
+    public void testLittleEndian() {
+        assertEquals(LITTLE_ENDIAN, nativeOrder()); // ut may always run on an LE machine
+
+        final Access<CharSequence> access = CharSequenceAccess.charSequenceAccess(LITTLE_ENDIAN);
+	assertSame(CharSequenceAccess.nativeCharSequenceAccess(), access);
+
+        assertEquals(buildNumber('A', 'B', 'C', 'D'), access.getLong(TEST_STRING, 0));
+        //assertEquals((buildNumber('A', 'B', 'C', 'D') >>> 8) | (((long)'E') << 56), access.getLong(TEST_STRING, 1));
+
+        assertEquals((int)buildNumber('A', 'B', '\0', '\0'), access.getInt(TEST_STRING, 0));
+        //assertEquals((int)(buildNumber('A', 'B', 'C', '\0') >>> 8), access.getInt(TEST_STRING, 1));
+        assertEquals(unsignedInt((int)buildNumber('A', 'B', '\0', '\0')), access.getUnsignedInt(TEST_STRING, 0));
+        //assertEquals(unsignedInt((int)buildNumber('A', 'B', 'C', '\0') >>> 8), access.getUnsignedInt(TEST_STRING, 1));
+
+        assertEquals((int)buildNumber('A', '\0', '\0', '\0'), access.getShort(TEST_STRING, 0));
+        //assertEquals((int)(short)(buildNumber('A', 'B', '\0', '\0') >>> 8), access.getShort(TEST_STRING, 1));
+        assertEquals(unsignedShort((short)buildNumber('A', '\0', '\0', '\0')), access.getUnsignedShort(TEST_STRING, 0));
+        //assertEquals(unsignedShort((short)(buildNumber('A', 'B', '\0', '\0') >>> 8)), access.getUnsignedShort(TEST_STRING, 1));
+
+        assertEquals((int)(byte)buildNumber('A', '\0', '\0', '\0'), access.getByte(TEST_STRING, 0));
+        assertEquals((int)(byte)(buildNumber('A', '\0', '\0', '\0') >>> 8), access.getByte(TEST_STRING, 1));
+        assertEquals(unsignedByte((byte)buildNumber('A', '\0', '\0', '\0')), access.getUnsignedByte(TEST_STRING, 0));
+        assertEquals(unsignedByte((byte)(buildNumber('A', '\0', '\0', '\0') >>> 8)), access.getUnsignedByte(TEST_STRING, 1));
+    }
+
+    @Test
+    public void testBigEndian() {
+        assertEquals(LITTLE_ENDIAN, nativeOrder()); // ut may always run on an LE machine
+
+        final Access<CharSequence> access = CharSequenceAccess.charSequenceAccess(BIG_ENDIAN);
+	assertNotSame(CharSequenceAccess.nativeCharSequenceAccess(), access);
+
+        assertEquals(buildNumber('D', 'C', 'B', 'A'), access.getLong(TEST_STRING, 0));
+        //assertEquals((buildNumber('D', 'C', 'B', 'A') << 8) | ((byte)('E'>>>8)), access.getLong(TEST_STRING, 1));
+
+        assertEquals((int)buildNumber('B', 'A', '\0', '\0'), access.getInt(TEST_STRING, 0));
+        //assertEquals((int)(buildNumber((char)('C'<<8), 'B', (char)('A'>>8), '\0') >>> 8), access.getInt(TEST_STRING, 1));
+        assertEquals(unsignedInt((int)buildNumber('B', 'A', '\0', '\0')), access.getUnsignedInt(TEST_STRING, 0));
+        //assertEquals(unsignedInt((int)buildNumber((char)('C'<<8), 'B', (char)('A'>>8), '\0') >>> 8), access.getUnsignedInt(TEST_STRING, 1));
+
+        assertEquals((int)buildNumber('A', '\0', '\0', '\0'), access.getShort(TEST_STRING, 0));
+        //assertEquals((int)(short)(buildNumber((char)('B'<<8), (char)('A'>>8), '\0', '\0') >>> 8), access.getShort(TEST_STRING, 1));
+        assertEquals(unsignedShort((short)buildNumber('A', '\0', '\0', '\0')), access.getUnsignedShort(TEST_STRING, 0));
+        //assertEquals(unsignedShort((short)(buildNumber((char)('B'<<8), (char)('A'>>8), '\0', '\0') >>> 8)), access.getUnsignedShort(TEST_STRING, 1));
+
+        assertEquals((int)(byte)(buildNumber('A', '\0', '\0', '\0') >> 8), access.getByte(TEST_STRING, 0));
+        assertEquals((int)(byte)buildNumber('A', '\0', '\0', '\0'), access.getByte(TEST_STRING, 1));
+        assertEquals(unsignedByte((byte)(buildNumber('A', '\0', '\0', '\0') >> 8)), access.getUnsignedByte(TEST_STRING, 0));
+        assertEquals(unsignedByte((byte)buildNumber('A', '\0', '\0', '\0')), access.getUnsignedByte(TEST_STRING, 1));
+    }
+}

--- a/src/test/java/net/openhft/hashing/CharSequenceAccessTest.java
+++ b/src/test/java/net/openhft/hashing/CharSequenceAccessTest.java
@@ -11,28 +11,28 @@ public class CharSequenceAccessTest {
     static String TEST_STRING = "ABCDEFGH";
 
     static long buildNumber(char ll, char lh, char hl, char hh) {
-        return unsignedShort(ll) | (unsignedShort(lh) << 16) | (((long)unsignedShort(hl)) << 32) | (((long)unsignedShort(hh)) << 48);
+        return ll | (((int)lh) << 16) | (((long)hl) << 32) | (((long)hh) << 48);
     }
 
     @Test
     public void testLittleEndian() {
-        assertEquals(LITTLE_ENDIAN, nativeOrder()); // ut may always run on an LE machine
+        assertEquals(LITTLE_ENDIAN, nativeOrder()); // ut is designed for LE machines
 
         final Access<CharSequence> access = CharSequenceAccess.charSequenceAccess(LITTLE_ENDIAN);
 	assertSame(CharSequenceAccess.nativeCharSequenceAccess(), access);
 
         assertEquals(buildNumber('A', 'B', 'C', 'D'), access.getLong(TEST_STRING, 0));
-        //assertEquals((buildNumber('A', 'B', 'C', 'D') >>> 8) | (((long)'E') << 56), access.getLong(TEST_STRING, 1));
+        assertEquals((buildNumber('A', 'B', 'C', 'D') >>> 8) | (((long)'E') << 56), access.getLong(TEST_STRING, 1));
 
         assertEquals((int)buildNumber('A', 'B', '\0', '\0'), access.getInt(TEST_STRING, 0));
-        //assertEquals((int)(buildNumber('A', 'B', 'C', '\0') >>> 8), access.getInt(TEST_STRING, 1));
+        assertEquals((int)(buildNumber('A', 'B', 'C', '\0') >>> 8), access.getInt(TEST_STRING, 1));
         assertEquals(unsignedInt((int)buildNumber('A', 'B', '\0', '\0')), access.getUnsignedInt(TEST_STRING, 0));
-        //assertEquals(unsignedInt((int)buildNumber('A', 'B', 'C', '\0') >>> 8), access.getUnsignedInt(TEST_STRING, 1));
+        assertEquals(unsignedInt((int)(buildNumber('A', 'B', 'C', '\0') >>> 8)), access.getUnsignedInt(TEST_STRING, 1));
 
         assertEquals((int)buildNumber('A', '\0', '\0', '\0'), access.getShort(TEST_STRING, 0));
-        //assertEquals((int)(short)(buildNumber('A', 'B', '\0', '\0') >>> 8), access.getShort(TEST_STRING, 1));
+        assertEquals((int)(short)(buildNumber('A', 'B', '\0', '\0') >>> 8), access.getShort(TEST_STRING, 1));
         assertEquals(unsignedShort((short)buildNumber('A', '\0', '\0', '\0')), access.getUnsignedShort(TEST_STRING, 0));
-        //assertEquals(unsignedShort((short)(buildNumber('A', 'B', '\0', '\0') >>> 8)), access.getUnsignedShort(TEST_STRING, 1));
+        assertEquals(unsignedShort((short)(buildNumber('A', 'B', '\0', '\0') >>> 8)), access.getUnsignedShort(TEST_STRING, 1));
 
         assertEquals((int)(byte)buildNumber('A', '\0', '\0', '\0'), access.getByte(TEST_STRING, 0));
         assertEquals((int)(byte)(buildNumber('A', '\0', '\0', '\0') >>> 8), access.getByte(TEST_STRING, 1));
@@ -42,23 +42,23 @@ public class CharSequenceAccessTest {
 
     @Test
     public void testBigEndian() {
-        assertEquals(LITTLE_ENDIAN, nativeOrder()); // ut may always run on an LE machine
+        assertEquals(LITTLE_ENDIAN, nativeOrder()); // ut is designed for LE machines
 
         final Access<CharSequence> access = CharSequenceAccess.charSequenceAccess(BIG_ENDIAN);
 	assertNotSame(CharSequenceAccess.nativeCharSequenceAccess(), access);
 
         assertEquals(buildNumber('D', 'C', 'B', 'A'), access.getLong(TEST_STRING, 0));
-        //assertEquals((buildNumber('D', 'C', 'B', 'A') << 8) | ((byte)('E'>>>8)), access.getLong(TEST_STRING, 1));
+        assertEquals((buildNumber('D', 'C', 'B', 'A') << 8) | ((byte)('E'>>>8)), access.getLong(TEST_STRING, 1));
 
         assertEquals((int)buildNumber('B', 'A', '\0', '\0'), access.getInt(TEST_STRING, 0));
-        //assertEquals((int)(buildNumber((char)('C'<<8), 'B', (char)('A'>>8), '\0') >>> 8), access.getInt(TEST_STRING, 1));
+        assertEquals((int)(buildNumber((char)('C'>>>8), 'B', 'A', '\0') >>> 8), access.getInt(TEST_STRING, 1));
         assertEquals(unsignedInt((int)buildNumber('B', 'A', '\0', '\0')), access.getUnsignedInt(TEST_STRING, 0));
-        //assertEquals(unsignedInt((int)buildNumber((char)('C'<<8), 'B', (char)('A'>>8), '\0') >>> 8), access.getUnsignedInt(TEST_STRING, 1));
+        assertEquals(unsignedInt((int)(buildNumber((char)('C'>>>8), 'B', 'A', '\0') >>> 8)), access.getUnsignedInt(TEST_STRING, 1));
 
         assertEquals((int)buildNumber('A', '\0', '\0', '\0'), access.getShort(TEST_STRING, 0));
-        //assertEquals((int)(short)(buildNumber((char)('B'<<8), (char)('A'>>8), '\0', '\0') >>> 8), access.getShort(TEST_STRING, 1));
+        assertEquals((int)(short)(buildNumber((char)('B'>>>8), 'A', '\0', '\0') >>> 8), access.getShort(TEST_STRING, 1));
         assertEquals(unsignedShort((short)buildNumber('A', '\0', '\0', '\0')), access.getUnsignedShort(TEST_STRING, 0));
-        //assertEquals(unsignedShort((short)(buildNumber((char)('B'<<8), (char)('A'>>8), '\0', '\0') >>> 8)), access.getUnsignedShort(TEST_STRING, 1));
+        assertEquals(unsignedShort((short)(buildNumber((char)('B'>>>8), 'A', '\0', '\0') >>> 8)), access.getUnsignedShort(TEST_STRING, 1));
 
         assertEquals((int)(byte)(buildNumber('A', '\0', '\0', '\0') >> 8), access.getByte(TEST_STRING, 0));
         assertEquals((int)(byte)buildNumber('A', '\0', '\0', '\0'), access.getByte(TEST_STRING, 1));

--- a/src/test/java/net/openhft/hashing/CharSequenceAccessTest.java
+++ b/src/test/java/net/openhft/hashing/CharSequenceAccessTest.java
@@ -19,7 +19,7 @@ public class CharSequenceAccessTest {
         assertEquals(LITTLE_ENDIAN, nativeOrder()); // ut is designed for LE machines
 
         final Access<CharSequence> access = CharSequenceAccess.charSequenceAccess(LITTLE_ENDIAN);
-	assertSame(CharSequenceAccess.nativeCharSequenceAccess(), access);
+        assertSame(CharSequenceAccess.nativeCharSequenceAccess(), access);
 
         assertEquals(buildNumber('A', 'B', 'C', 'D'), access.getLong(TEST_STRING, 0));
         assertEquals((buildNumber('A', 'B', 'C', 'D') >>> 8) | (((long)'E') << 56), access.getLong(TEST_STRING, 1));
@@ -45,7 +45,7 @@ public class CharSequenceAccessTest {
         assertEquals(LITTLE_ENDIAN, nativeOrder()); // ut is designed for LE machines
 
         final Access<CharSequence> access = CharSequenceAccess.charSequenceAccess(BIG_ENDIAN);
-	assertNotSame(CharSequenceAccess.nativeCharSequenceAccess(), access);
+        assertNotSame(CharSequenceAccess.nativeCharSequenceAccess(), access);
 
         assertEquals(buildNumber('D', 'C', 'B', 'A'), access.getLong(TEST_STRING, 0));
         assertEquals((buildNumber('D', 'C', 'B', 'A') << 8) | ((byte)('E'>>>8)), access.getLong(TEST_STRING, 1));


### PR DESCRIPTION
detect unalign offsets in runtime. this may take in a little performance cost, but should work. all ut cases are designed for little endian machines.

Close #36 