### PR TITLE
Support Compact String from JDK9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -197,6 +197,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <enableAssertions>true</enableAssertions>
+                    <reuseForks>false</reuseForks>
                 </configuration>
             </plugin>
 
@@ -344,6 +345,24 @@
             <properties>
                 <maven.compiler.release>${project.target.release}</maven.compiler.release>
             </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>test-without-compact-string</id>
+                                <goals>
+                                    <goal>test</goal>
+                                </goals>
+                                <configuration>
+                                    <argLine>-XX:-CompactStrings</argLine>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
     </profiles>
 </project>

--- a/src/main/java/net/openhft/hashing/CompactLatin1CharSequenceAccess.java
+++ b/src/main/java/net/openhft/hashing/CompactLatin1CharSequenceAccess.java
@@ -1,0 +1,195 @@
+package net.openhft.hashing;
+
+import java.nio.ByteOrder;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
+
+import static java.nio.ByteOrder.BIG_ENDIAN;
+import static java.nio.ByteOrder.LITTLE_ENDIAN;
+import static net.openhft.hashing.UnsafeAccess.BYTE_BASE;
+
+/*
+ * Compress Latin1 Access
+ *
+ * Explaination:
+ *
+ * compressed idx :  0  1  2  3  4  5
+ * compressed bytes: 12 34 56 78 9A BC
+ *
+ * compressed idx :  0     1     2     3     4     5
+ * expanded index :  0  1  2  3  4  5  6  7  8  9  A  B
+ * expanded LE mem:  12 00 34 00 56 00 78 00 9A 00 BC 00
+ * expanded BE mem:  00 12 00 34 00 56 00 78 00 9A 00 BC
+ *   align LE byte:  []    --> 0x12
+ *   align BE byte:  []    --> 0x00
+ * unalign LE byte:     [] --> 0x00
+ * unalign BE byte:     [] --> 0x12
+ *
+ * compressed idx :  0     1     2     3     4     5
+ * expanded index :  0  1  2  3  4  5  6  7  8  9  A  B
+ * expanded LE mem:  12 00 34 00 56 00 78 00 9A 00 BC 00
+ * expanded BE mem:  00 12 00 34 00 56 00 78 00 9A 00 BC
+ *   align LE char:  [___]    --> 0x12
+ *   align BE char:  [___]    --> 0x12
+ * unalign LE char:     [___] --> 0x3400
+ * unalign BE char:     [___] --> 0x1200
+ *
+ * compressed idx :  0     1     2     3     4     5
+ * expanded index :  0  1  2  3  4  5  6  7  8  9  A  B
+ * expanded LE mem:  12 00 34 00 56 00 78 00 9A 00 BC 00
+ * expanded BE mem:  00 12 00 34 00 56 00 78 00 9A 00 BC
+ *   align LE int :  [_________]    --> 0x340012
+ *   align BE int :  [_________]    --> 0x120034
+ * unalign LE int :     [_________] --> 0x56003400
+ * unalign BE int :     [_________] --> 0x12003400
+ *
+ * compressed idx :  0     1     2     3     4     5
+ * expanded index :  0  1  2  3  4  5  6  7  8  9  A  B
+ * expanded LE mem:  12 00 34 00 56 00 78 00 9A 00 BC 00
+ * expanded BE mem:  00 12 00 34 00 56 00 78 00 9A 00 BC
+ *   align LE long:  [_____________________]    --> 0x78005600340012
+ *   align BE long:  [_____________________]    --> 0x12003400560078
+ * unalign LE long:     [_____________________] --> 0x9A00780056003400
+ * unalign BE long:     [_____________________] --> 0x1200340056007800
+ *
+ * Parameters:
+ *
+ * Parameters must satisfy: 0 <= offset < offset + typeWidth <= input.length*2.
+ * When offset + typeWidth >= (input.length + 1)*2, the behavior is undefined, throwing a exception
+ * or returning dirty results.
+ * When offset + typeWidth == input.length*2 + 1,
+ * 1) on BE machine, the result is correct
+ * 2) on LE machine, the behavior is undefined, throwing a exception or returning dirty results.
+ *
+ * compressed idx :  0
+ * expanded index :  0  1
+ * expanded LE mem:  12 00
+ * expanded BE mem:  00 12
+ *   align LE char:  [___]    --> 0x12
+ *   align BE char:  [___]    --> 0x12
+ * unalign LE char:     [_??] --> 0x??00, exception or dirty
+ * unalign BE char:     [_00] --> 0x1200, correct
+ *
+ * Notes: This access is based on the UnsafeAccess, so only works for the native order.
+ */
+@ParametersAreNonnullByDefault
+abstract class CompactLatin1CharSequenceAccess extends Access<byte[]> {
+    @NotNull
+    static final CompactLatin1CharSequenceAccess INSTANCE
+        = ByteOrder.nativeOrder() == LITTLE_ENDIAN ? LittleEndian.INSTANCE : BigEndian.INSTANCE;
+
+    @NotNull
+    private static final UnsafeAccess UNSAFE = UnsafeAccess.INSTANCE;
+
+    private static int ix(final long offset) {
+        return (int) (offset >> 1);
+    }
+
+    protected static long getLong(final byte[] input, final long offset, final int offAdjust) {
+        final int byteIdx = ix(offset + offAdjust);
+        final int shift = ((int)offset & 1) << 3;
+        final long compact = UNSAFE.getUnsignedInt(input, BYTE_BASE + byteIdx);
+        long expanded = ((compact << 16) | compact) & 0xFFFF0000FFFFL;
+        expanded = ((expanded << 8) | expanded) & 0xFF00FF00FF00FFL;
+        return expanded << shift;
+    }
+
+    protected static int getInt(final byte[] input, final long offset, final int offAdjust) {
+        final int byteIdx = ix(offset + offAdjust);
+        final int shift = ((int)offset & 1) << 3;
+        final int compact = UNSAFE.getUnsignedShort(input, BYTE_BASE + byteIdx);
+        final int expanded = ((compact << 8) | compact) & 0xFF00FF;
+        return expanded << shift;
+    }
+
+    protected static int getShort(final byte[] input, final long offset, final int offAdjust) {
+        final int byteIdx = ix(offset + offAdjust);
+        final int shift = ((int)offset & 1) << 3;
+        return Primitives.unsignedByte(input[byteIdx]) << shift;
+    }
+
+    protected static int getByte(final byte[] input, final long offset, final int z) {
+        if (z == ((int)offset & 1)) {
+            return 0;
+        } else {
+            return Primitives.unsignedByte(input[ix(offset)]);
+        }
+    }
+
+    private CompactLatin1CharSequenceAccess() {}
+
+    @Override
+    public long getUnsignedInt(final byte[] input, final long offset) {
+        return Primitives.unsignedInt(getInt(input, offset));
+    }
+
+    @Override
+    public int getUnsignedShort(final byte[] input, final long offset) {
+        return Primitives.unsignedShort(getShort(input, offset));
+    }
+
+    @Override
+    public int getUnsignedByte(final byte[] input, final long offset) {
+        return Primitives.unsignedByte(getByte(input, offset));
+    }
+
+    @Override
+    @NotNull
+    public ByteOrder byteOrder(final byte[] input) {
+        return UNSAFE.byteOrder(input);
+    }
+
+    private static class LittleEndian extends CompactLatin1CharSequenceAccess {
+        private static final LittleEndian INSTANCE = new LittleEndian();
+
+        private LittleEndian() {}
+
+        @Override
+        public long getLong(final byte[] input, final long offset) {
+            return getLong(input, offset, 1);
+        }
+
+        @Override
+        public int getInt(final byte[] input, final long offset) {
+            return getInt(input, offset, 1);
+        }
+
+        @Override
+        public int getShort(final byte[] input, final long offset) {
+            return getShort(input, offset, 1);
+        }
+
+        @Override
+        public int getByte(final byte[] input, final long offset) {
+            return getByte(input, offset, 1);
+        }
+    }
+
+    private static class BigEndian extends CompactLatin1CharSequenceAccess {
+        private static final BigEndian INSTANCE = new BigEndian();
+
+        private BigEndian() {}
+
+        @Override
+        public long getLong(final byte[] input, final long offset) {
+            return getLong(input, offset, 0);
+        }
+
+        @Override
+        public int getInt(final byte[] input, final long offset) {
+            return getInt(input, offset, 0);
+        }
+
+        @Override
+        public int getShort(final byte[] input, final long offset) {
+            return getShort(input, offset, 0);
+        }
+
+        @Override
+        public int getByte(final byte[] input, final long offset) {
+            return getByte(input, offset, 0);
+        }
+    }
+}

--- a/src/main/java/net/openhft/hashing/ModernCompactStringHash.java
+++ b/src/main/java/net/openhft/hashing/ModernCompactStringHash.java
@@ -1,0 +1,66 @@
+package net.openhft.hashing;
+
+import java.lang.reflect.Field;
+import javax.annotation.ParametersAreNonnullByDefault;
+import static net.openhft.hashing.UnsafeAccess.*;
+import static net.openhft.hashing.Util.*;
+
+@ParametersAreNonnullByDefault
+enum ModernCompactStringHash implements StringHash {
+    INSTANCE;
+
+    private static final long valueOffset;
+    private static final boolean enableCompactStrings;
+    private static final Access<byte[]> compactLatin1Access
+        = CompactLatin1CharSequenceAccess.INSTANCE;
+
+    static {
+        try {
+            final Field valueField = String.class.getDeclaredField("value");
+            valueOffset = UnsafeAccess.UNSAFE.objectFieldOffset(valueField);
+
+            final byte[] value = (byte[]) UnsafeAccess.UNSAFE.getObject("A", valueOffset);
+            enableCompactStrings = (1 == value.length);
+        } catch (final NoSuchFieldException e) {
+            throw new AssertionError(e);
+        }
+    }
+
+    @Override
+    public long longHash(final String s, final LongHashFunction hashFunction,
+                    final int off, final int len) {
+        final int sl = s.length();
+        if (len <= 0 || sl <= 0) {
+            checkArrayOffs(sl, off, len); // check as chars
+            return hashFunction.hashVoid();
+        } else {
+            final byte[] value = (byte[]) UnsafeAccess.UNSAFE.getObject(s, valueOffset);
+            if (enableCompactStrings && sl == value.length) {
+                checkArrayOffs(sl, off, len); // check as chars
+                // 'off' and 'len' are passed as bytes
+                return hashFunction.hash(value, compactLatin1Access, (long)off*2L, (long)len*2L);
+            } else {
+                return hashFunction.hashBytes(value, off*2, len*2); // hash as bytes
+            }
+        }
+    }
+
+    @Override
+    public void hash(final String s, final LongTupleHashFunction hashFunction,
+                    final int off, final int len, final long[] result) {
+        final int sl = s.length();
+        if (len <= 0 || sl <= 0) {
+            checkArrayOffs(sl, off, len); // check as chars
+            hashFunction.hashVoid(result);
+        } else {
+            final byte[] value = (byte[]) UnsafeAccess.UNSAFE.getObject(s, valueOffset);
+            if (enableCompactStrings && sl == value.length) {
+                checkArrayOffs(sl, off, len); // check as chars
+                // 'off' and 'len' are passed as bytes
+                hashFunction.hash(value, compactLatin1Access, (long)off*2L, (long)len*2L, result);
+            } else {
+                hashFunction.hashBytes(value, off*2, len*2, result); // hash as bytes
+            }
+        }
+    }
+}

--- a/src/main/java/net/openhft/hashing/Util.java
+++ b/src/main/java/net/openhft/hashing/Util.java
@@ -10,28 +10,48 @@ import static java.nio.ByteOrder.*;
 final class Util {
     static final boolean NATIVE_LITTLE_ENDIAN = nativeOrder() == LITTLE_ENDIAN;
 
+    /* Known java.vm.name list:
+     *
+     *   HotSpot:
+     *   - Java HotSpot(TM) xx-Bit Server VM
+     *   - OpenJDK xx-Bit Server VM
+     *
+     *   J9:
+     *   - Eclipse OpenJ9 VM
+     *   - IBM J9 VM
+     */
+    static private boolean isHotSpotVM(@NotNull final String name) {
+        return name.contains("HotSpot") || name.contains("OpenJDK");
+    }
+    static private boolean isJ9VM(@NotNull final String name) {
+        return name.contains("Eclipse OpenJ9") || name.contains("IBM J9");
+    }
+
     @NotNull
     static final StringHash VALID_STRING_HASH;
     static  {
         StringHash stringHash = null;
         try {
-            if (System.getProperty("java.vm.name").contains("HotSpot")) {
+            final String vmName = System.getProperty("java.vm.name");
+            if (isHotSpotVM(vmName) || isJ9VM(vmName)) {
                 final String javaVersion = System.getProperty("java.version");
                 if (javaVersion.compareTo("1.7.0_06") >= 0) {
                     if (javaVersion.compareTo("1.9") >= 0) {
-                        stringHash = UnknownJvmStringHash.INSTANCE;
+                        // JDK 9+
+                        stringHash = ModernCompactStringHash.INSTANCE;
                     } else {
+                        // JDK [1.7.0_06, 9)
                         stringHash = ModernHotSpotStringHash.INSTANCE;
                     }
                 } else {
+                    // JDK [1.7, 1.7.0_06)
                     stringHash = HotSpotPrior7u6StringHash.INSTANCE;
                 }
             } else {
                 // try to initialize this version anyway
                 stringHash = HotSpotPrior7u6StringHash.INSTANCE;
             }
-        } catch (final Throwable e) {
-            // ignore
+        } catch (final Throwable ignore) {
         } finally {
             if (null == stringHash) {
                 VALID_STRING_HASH = UnknownJvmStringHash.INSTANCE;

--- a/src/test/java/net/openhft/hashing/CompactLatin1CharSequenceAccessTest.java
+++ b/src/test/java/net/openhft/hashing/CompactLatin1CharSequenceAccessTest.java
@@ -1,0 +1,60 @@
+package net.openhft.hashing;
+
+import org.junit.Test;
+import java.nio.ByteOrder;
+
+import static java.nio.ByteOrder.BIG_ENDIAN;
+import static java.nio.ByteOrder.LITTLE_ENDIAN;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assume.assumeTrue;
+
+public class CompactLatin1CharSequenceAccessTest {
+    static private final Access<byte[]> access = CompactLatin1CharSequenceAccess.INSTANCE;
+    static private final byte[] b = { (byte)0xF1, (byte)0xE2, (byte)0xD3, (byte)0xC4, (byte)0xB5 };
+
+    @Test
+    public void testLE() {
+        assumeTrue(ByteOrder.nativeOrder() == LITTLE_ENDIAN);
+
+        assertEquals(    0xC400D300E200F1L, access.getLong(b, 0));
+        assertEquals(0xB500C400D300E200L,   access.getLong(b, 1));
+
+        assertEquals(                       0xE200F1,    access.getInt(b, 0));
+        assertEquals(                       0xD300E200,  access.getInt(b, 1));
+        assertEquals(Primitives.unsignedInt(0xE200F1),   access.getUnsignedInt(b, 0));
+        assertEquals(Primitives.unsignedInt(0xD300E200), access.getUnsignedInt(b, 1));
+
+        assertEquals(                         0xF1,    access.getShort(b, 0));
+        assertEquals(                         0xE200,  access.getShort(b, 1));
+        assertEquals(Primitives.unsignedShort(0xF1),   access.getUnsignedShort(b, 0));
+        assertEquals(Primitives.unsignedShort(0xE200), access.getUnsignedShort(b, 1));
+
+        assertEquals(                        0xF1,  access.getByte(b, 0));
+        assertEquals(                           0,  access.getByte(b, 1));
+        assertEquals(Primitives.unsignedByte(0xF1), access.getUnsignedByte(b, 0));
+        assertEquals(                           0,  access.getUnsignedByte(b, 1));
+    }
+
+    @Test
+    public void testBE() {
+        assumeTrue(ByteOrder.nativeOrder() == BIG_ENDIAN);
+
+        assertEquals(0xF100E200D300C4L,   access.getLong(b, 0));
+        assertEquals(0xF100E200D300C400L, access.getLong(b, 1));
+
+        assertEquals(                       0xF100E2,    access.getInt(b, 0));
+        assertEquals(                       0xF100E200,  access.getInt(b, 1));
+        assertEquals(Primitives.unsignedInt(0xF100E2),   access.getUnsignedInt(b, 0));
+        assertEquals(Primitives.unsignedInt(0xF100E200), access.getUnsignedInt(b, 1));
+
+        assertEquals(                         0xF1,    access.getShort(b, 0));
+        assertEquals(                         0xF100,  access.getShort(b, 1));
+        assertEquals(Primitives.unsignedShort(0xF1),   access.getUnsignedShort(b, 0));
+        assertEquals(Primitives.unsignedShort(0xF100), access.getUnsignedShort(b, 1));
+
+        assertEquals(                           0,  access.getByte(b, 0));
+        assertEquals(                        0xF1,  access.getByte(b, 1));
+        assertEquals(                           0,  access.getUnsignedByte(b, 0));
+        assertEquals(Primitives.unsignedByte(0xF1), access.getUnsignedByte(b, 1));
+    }
+}

--- a/src/test/java/net/openhft/hashing/CompactLatin1CharSequenceAccessTest.java
+++ b/src/test/java/net/openhft/hashing/CompactLatin1CharSequenceAccessTest.java
@@ -25,11 +25,11 @@ public class CompactLatin1CharSequenceAccessTest {
         assertEquals(Primitives.unsignedInt(0xD300E200), access.getUnsignedInt(b, 1));
 
         assertEquals(                         0xF1,    access.getShort(b, 0));
-        assertEquals(                         0xE200,  access.getShort(b, 1));
+        assertEquals(             (int)(short)0xE200,  access.getShort(b, 1));
         assertEquals(Primitives.unsignedShort(0xF1),   access.getUnsignedShort(b, 0));
         assertEquals(Primitives.unsignedShort(0xE200), access.getUnsignedShort(b, 1));
 
-        assertEquals(                        0xF1,  access.getByte(b, 0));
+        assertEquals(             (int)(byte)0xF1,  access.getByte(b, 0));
         assertEquals(                           0,  access.getByte(b, 1));
         assertEquals(Primitives.unsignedByte(0xF1), access.getUnsignedByte(b, 0));
         assertEquals(                           0,  access.getUnsignedByte(b, 1));
@@ -48,12 +48,12 @@ public class CompactLatin1CharSequenceAccessTest {
         assertEquals(Primitives.unsignedInt(0xF100E200), access.getUnsignedInt(b, 1));
 
         assertEquals(                         0xF1,    access.getShort(b, 0));
-        assertEquals(                         0xF100,  access.getShort(b, 1));
+        assertEquals(             (int)(short)0xF100,  access.getShort(b, 1));
         assertEquals(Primitives.unsignedShort(0xF1),   access.getUnsignedShort(b, 0));
         assertEquals(Primitives.unsignedShort(0xF100), access.getUnsignedShort(b, 1));
 
         assertEquals(                           0,  access.getByte(b, 0));
-        assertEquals(                        0xF1,  access.getByte(b, 1));
+        assertEquals(             (int)(byte)0xF1,  access.getByte(b, 1));
         assertEquals(                           0,  access.getUnsignedByte(b, 0));
         assertEquals(Primitives.unsignedByte(0xF1), access.getUnsignedByte(b, 1));
     }

--- a/src/test/java/net/openhft/hashing/LongHashFunctionTest.java
+++ b/src/test/java/net/openhft/hashing/LongHashFunctionTest.java
@@ -26,6 +26,7 @@ import static java.nio.ByteOrder.LITTLE_ENDIAN;
 import static java.nio.ByteOrder.nativeOrder;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.fail;
 
 public class LongHashFunctionTest {
 
@@ -43,6 +44,7 @@ public class LongHashFunctionTest {
         testArrays(f, data, eh, len, bb);
         testByteBuffers(f, eh, len, bb);
         testCharSequences(f, eh, len, bb);
+        testLatin1String(f, data);
         testMemory(f, eh, len, bb);
     }
 
@@ -210,5 +212,19 @@ public class LongHashFunctionTest {
         directBB.put(bb);
         assertEquals("memory", eh, f.hashMemory(Util.getDirectBufferAddress(directBB), len));
         ((Buffer)bb).clear();
+    }
+
+    private static void testLatin1String(LongHashFunction f, byte[] data) {
+        // test for compact string from JDK 9
+        try {
+            String inputStr = new String(data, "ISO-8859-1");
+            char[] inputCharArray = new char[data.length];
+            for (int i = 0; i < data.length; ++i) {
+                inputCharArray[i] = (char)(data[i]&0xFF);
+            }
+            assertEquals(f.hashChars(inputStr), f.hashChars(inputCharArray));
+        } catch (Exception e) {
+            fail(e.toString());
+        }
     }
 }

--- a/src/test/java/net/openhft/hashing/LongTupleHashFunctionTest.java
+++ b/src/test/java/net/openhft/hashing/LongTupleHashFunctionTest.java
@@ -39,6 +39,7 @@ public class LongTupleHashFunctionTest {
         testArrays(f, data, eh, len, bb);
         testByteBuffers(f, eh, len, bb);
         testCharSequences(f, eh, len, bb);
+        testLatin1String(f, data);
         testMemory(f, eh, len, bb);
     }
 
@@ -247,5 +248,19 @@ public class LongTupleHashFunctionTest {
         directBB.put(bb);
         assertArrayEquals("memory", eh, f.hashMemory(Util.getDirectBufferAddress(directBB), len));
         ((Buffer)bb).clear();
+    }
+
+    private static void testLatin1String(LongTupleHashFunction f, byte[] data) {
+        // test for compact string from JDK 9
+        try {
+            String inputStr = new String(data, "ISO-8859-1");
+            char[] inputCharArray = new char[data.length];
+            for (int i = 0; i < data.length; ++i) {
+                inputCharArray[i] = (char)(data[i]&0xFF);
+            }
+            assertArrayEquals(f.hashChars(inputStr), f.hashChars(inputCharArray));
+        } catch (Exception e) {
+            fail(e.toString());
+        }
     }
 }

--- a/src/test/java/net/openhft/hashing/UtilTest.java
+++ b/src/test/java/net/openhft/hashing/UtilTest.java
@@ -1,0 +1,15 @@
+package net.openhft.hashing;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertNotSame;
+
+public class UtilTest {
+
+    @Test
+    public void testStringHash() {
+        // This is a sentinel test to make sure that in all known VMs it will not fall back to use
+        // native CharSequenceAccess
+        assertNotSame(Util.VALID_STRING_HASH, UnknownJvmStringHash.INSTANCE);
+    }
+}


### PR DESCRIPTION
Add `ModernCompactStringHash` and `CompactLatin1CharSequenceAccess` to support JDK 9's compact string.

Close #20 