### PR TITLE
Use `implementation` instead of `compile` for Gradle example

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -92,7 +92,7 @@ Gradle:
 [source, groovy]
 ----
 dependencies {
-    compile 'net.openhft:zero-allocation-hashing:0.10.1'
+    implementation 'net.openhft:zero-allocation-hashing:0.10.1'
 }
 ----
 


### PR DESCRIPTION
https://docs.gradle.org/current/userguide/java_library_plugin.html#sec:java_library_separation