### PR TITLE
Refactor to simplify implementing hash functions

### DIFF
--- a/src/main/java/net/openhft/hashing/Access.java
+++ b/src/main/java/net/openhft/hashing/Access.java
@@ -252,6 +252,15 @@ public abstract class Access<T> {
      */
     public abstract int getByte(T input, long offset);
 
+    // short names
+    public long i64(final T input, final long offset) { return getLong(input, offset); }
+    public long u32(final T input, final long offset) { return getUnsignedInt(input, offset); }
+    public  int i32(final T input, final long offset) { return getInt(input, offset); }
+    public  int u16(final T input, final long offset) { return getUnsignedShort(input, offset); }
+    public  int i16(final T input, final long offset) { return getShort(input, offset); }
+    public  int  u8(final T input, final long offset) { return getUnsignedByte(input, offset); }
+    public  int  i8(final T input, final long offset) { return getByte(input, offset); }
+
     /**
      * The byte order in which all multi-byte {@code getXXX()} reads from the given {@code input}
      * are performed.

--- a/src/main/java/net/openhft/hashing/ByteBufferAccess.java
+++ b/src/main/java/net/openhft/hashing/ByteBufferAccess.java
@@ -21,6 +21,7 @@ import java.nio.ByteOrder;
 
 final class ByteBufferAccess extends Access<ByteBuffer> {
     public static final ByteBufferAccess INSTANCE = new ByteBufferAccess();
+    private static final Access<ByteBuffer> INSTANCE_REVERSE = Access.newDefaultReverseAccess(INSTANCE);
 
     private ByteBufferAccess() {}
 
@@ -62,5 +63,10 @@ final class ByteBufferAccess extends Access<ByteBuffer> {
     @Override
     public ByteOrder byteOrder(ByteBuffer input) {
         return input.order();
+    }
+
+    @Override
+    protected Access<ByteBuffer> reverseAccess() {
+        return INSTANCE_REVERSE;
     }
 }

--- a/src/main/java/net/openhft/hashing/CharSequenceAccess.java
+++ b/src/main/java/net/openhft/hashing/CharSequenceAccess.java
@@ -107,6 +107,7 @@ abstract class CharSequenceAccess extends Access<CharSequence> {
 
     private static class LittleEndianCharSequenceAccess extends CharSequenceAccess {
         private static final CharSequenceAccess INSTANCE = new LittleEndianCharSequenceAccess();
+        private static final Access<CharSequence> INSTANCE_REVERSE = Access.newDefaultReverseAccess(INSTANCE);
 
         private LittleEndianCharSequenceAccess() {}
 
@@ -134,10 +135,16 @@ abstract class CharSequenceAccess extends Access<CharSequence> {
         public ByteOrder byteOrder(CharSequence input) {
             return LITTLE_ENDIAN;
         }
+
+        @Override
+        protected Access<CharSequence> reverseAccess() {
+            return INSTANCE_REVERSE;
+        }
     }
 
     private static class BigEndianCharSequenceAccess extends CharSequenceAccess {
         private static final CharSequenceAccess INSTANCE = new BigEndianCharSequenceAccess();
+        private static final Access<CharSequence> INSTANCE_REVERSE = Access.newDefaultReverseAccess(INSTANCE);
 
         private BigEndianCharSequenceAccess() {}
 
@@ -164,6 +171,11 @@ abstract class CharSequenceAccess extends Access<CharSequence> {
         @Override
         public ByteOrder byteOrder(CharSequence input) {
             return BIG_ENDIAN;
+        }
+
+        @Override
+        protected Access<CharSequence> reverseAccess() {
+            return INSTANCE_REVERSE;
         }
     }
 }

--- a/src/main/java/net/openhft/hashing/CityAndFarmHash_1_1.java
+++ b/src/main/java/net/openhft/hashing/CityAndFarmHash_1_1.java
@@ -26,8 +26,6 @@ import static net.openhft.hashing.Util.NATIVE_LITTLE_ENDIAN;
  * https://github.com/google/cityhash/blob/8af9b8c2b889d80c22d6bc26ba0df1afb79a30db/src/city.cc.
  */
 class CityAndFarmHash_1_1 {
-    CityAndFarmHash_1_1() {}
-
     static final long K0 = 0xc3a5c85c97cb3127L;
     private static final long K1 = 0xb492b66fbe98f273L;
     private static final long K2 = 0x9ae16a3b2f90404fL;
@@ -70,27 +68,19 @@ class CityAndFarmHash_1_1 {
         return hashLen16(c, d, mul);
     }
 
-    static <T> long fetch64(Access<T> access, T in, long off) {
-        return access.getLong(in, off);
-    }
-
-    static <T> int fetch32(Access<T> access, T in, long off) {
-        return access.getInt(in, off);
-    }
-
     static private <T> long hashLen0To16(Access<T> access, T in, long off, long len) {
         if (len >= 8L) {
-            long a = fetch64(access, in, off);
-            long b = fetch64(access, in, off + len - 8L);
+            long a = access.i64(in, off);
+            long b = access.i64(in, off + len - 8L);
             return hash8To16Bytes(len, a, b);
         } else if (len >= 4L) {
-            long a = Primitives.unsignedInt(fetch32(access, in, off));
-            long b = Primitives.unsignedInt(fetch32(access, in, off + len - 4L));
+            long a = access.u32(in, off);
+            long b = access.u32(in, off + len - 4L);
             return hash4To7Bytes(len, a, b);
         } else if (len > 0L) {
-            int a = access.getUnsignedByte(in, off);
-            int b = access.getUnsignedByte(in, off + (len >> 1));
-            int c = access.getUnsignedByte(in, off + len - 1L);
+            int a = access.u8(in, off);
+            int b = access.u8(in, off + (len >> 1));
+            int c = access.u8(in, off + len - 1L);
             return hash1To3Bytes((int) len, a, b, c);
         }
         return K2;
@@ -98,24 +88,24 @@ class CityAndFarmHash_1_1 {
 
     static private <T> long hashLen17To32(Access<T> access, T in, long off, long len) {
         long mul = mul(len);
-        long a = fetch64(access, in, off) * K1;
-        long b = fetch64(access, in, off + 8L);
-        long c = fetch64(access, in, off + len - 8L) * mul;
-        long d = fetch64(access, in, off + len - 16L) * K2;
+        long a = access.i64(in, off) * K1;
+        long b = access.i64(in, off + 8L);
+        long c = access.i64(in, off + len - 8L) * mul;
+        long d = access.i64(in, off + len - 16L) * K2;
         return hashLen16(rotateRight(a + b, 43) + rotateRight(c, 30) + d,
                 a + rotateRight(b + K2, 18) + c, mul);
     }
 
     static private <T> long cityHashLen33To64(Access<T> access, T in, long off, long len) {
         long mul = mul(len);
-        long a = fetch64(access, in, off) * K2;
-        long b = fetch64(access, in, off + 8L);
-        long c = fetch64(access, in, off + len - 24L);
-        long d = fetch64(access, in, off + len - 32L);
-        long e = fetch64(access, in, off + 16L) * K2;
-        long f = fetch64(access, in, off + 24L) * 9L;
-        long g = fetch64(access, in, off + len - 8L);
-        long h = fetch64(access, in, off + len - 16L) * mul;
+        long a = access.i64(in, off) * K2;
+        long b = access.i64(in, off + 8L);
+        long c = access.i64(in, off + len - 24L);
+        long d = access.i64(in, off + len - 32L);
+        long e = access.i64(in, off + 16L) * K2;
+        long f = access.i64(in, off + 24L) * 9L;
+        long g = access.i64(in, off + len - 8L);
+        long h = access.i64(in, off + len - 16L) * mul;
         long u = rotateRight(a + g, 43) + (rotateRight(b, 30) + c) * 9L;
         long v = ((a + g) ^ d) + f + 1L;
         long w = reverseBytes((u + v) * mul) + h;
@@ -138,10 +128,10 @@ class CityAndFarmHash_1_1 {
             return cityHashLen33To64(access, in, off, len);
         }
 
-        long x = fetch64(access, in, off + len - 40L);
-        long y = fetch64(access, in, off + len - 16L) + fetch64(access, in, off + len - 56L);
-        long z = hashLen16(fetch64(access, in, off + len - 48L) + len,
-                fetch64(access, in, off + len - 24L));
+        long x = access.i64(in, off + len - 40L);
+        long y = access.i64(in, off + len - 16L) + access.i64(in, off + len - 56L);
+        long z = hashLen16(access.i64(in, off + len - 48L) + len,
+                access.i64(in, off + len - 24L));
 
         long vFirst, vSecond, wFirst, wSecond;
 
@@ -150,10 +140,10 @@ class CityAndFarmHash_1_1 {
         // WeakHashLen32WithSeeds
         long a3 = len;
         long b3 = z;
-        long w4 = fetch64(access, in, off + len - 64L);
-        long x4 = fetch64(access, in, off + len - 64L + 8L);
-        long y4 = fetch64(access, in, off + len - 64L + 16L);
-        long z4 = fetch64(access, in, off + len - 64L + 24L);
+        long w4 = access.i64(in, off + len - 64L);
+        long x4 = access.i64(in, off + len - 64L + 8L);
+        long y4 = access.i64(in, off + len - 64L + 16L);
+        long z4 = access.i64(in, off + len - 64L + 24L);
         a3 += w4;
         b3 = rotateRight(b3 + a3 + z4, 21);
         long c3 = a3;
@@ -165,10 +155,10 @@ class CityAndFarmHash_1_1 {
         // WeakHashLen32WithSeeds
         long a2 = y + K1;
         long b2 = x;
-        long w3 = fetch64(access, in, off + len - 32L);
-        long x3 = fetch64(access, in, off + len - 32L + 8L);
-        long y3 = fetch64(access, in, off + len - 32L + 16L);
-        long z3 = fetch64(access, in, off + len - 32L + 24L);
+        long w3 = access.i64(in, off + len - 32L);
+        long x3 = access.i64(in, off + len - 32L + 8L);
+        long y3 = access.i64(in, off + len - 32L + 16L);
+        long z3 = access.i64(in, off + len - 32L + 24L);
         a2 += w3;
         b2 = rotateRight(b2 + a2 + z3, 21);
         long c2 = a2;
@@ -177,23 +167,23 @@ class CityAndFarmHash_1_1 {
         wFirst = a2 + z3;
         wSecond = b2 + c2;
 
-        x = x * K1 + fetch64(access, in, off);
+        x = x * K1 + access.i64(in, off);
 
         len = (len - 1L) & (~63L);
         do {
-            x = rotateRight(x + y + vFirst + fetch64(access, in, off + 8L), 37) * K1;
-            y = rotateRight(y + vSecond + fetch64(access, in, off + 48L), 42) * K1;
+            x = rotateRight(x + y + vFirst + access.i64(in, off + 8L), 37) * K1;
+            y = rotateRight(y + vSecond + access.i64(in, off + 48L), 42) * K1;
             x ^= wSecond;
-            y += vFirst + fetch64(access, in, off + 40L);
+            y += vFirst + access.i64(in, off + 40L);
             z = rotateRight(z + wFirst, 33) * K1;
 
             // WeakHashLen32WithSeeds
             long a1 = vSecond * K1;
             long b1 = x + wFirst;
-            long w2 = fetch64(access, in, off);
-            long x2 = fetch64(access, in, off + 8L);
-            long y2 = fetch64(access, in, off + 16L);
-            long z2 = fetch64(access, in, off + 24L);
+            long w2 = access.i64(in, off);
+            long x2 = access.i64(in, off + 8L);
+            long y2 = access.i64(in, off + 16L);
+            long z2 = access.i64(in, off + 24L);
             a1 += w2;
             b1 = rotateRight(b1 + a1 + z2, 21);
             long c1 = a1;
@@ -204,11 +194,11 @@ class CityAndFarmHash_1_1 {
 
             // WeakHashLen32WithSeeds
             long a = z + wSecond;
-            long b = y + fetch64(access, in, off + 16L);
-            long w1 = fetch64(access, in, off + 32L);
-            long x1 = fetch64(access, in, off + 32L + 8L);
-            long y1 = fetch64(access, in, off + 32L + 16L);
-            long z1 = fetch64(access, in, off + 32L + 24L);
+            long b = y + access.i64(in, off + 16L);
+            long w1 = access.i64(in, off + 32L);
+            long x1 = access.i64(in, off + 32L + 8L);
+            long y1 = access.i64(in, off + 32L + 16L);
+            long z1 = access.i64(in, off + 32L + 24L);
             a += w1;
             b = rotateRight(b + a + z1, 21);
             long c = a;
@@ -335,16 +325,16 @@ class CityAndFarmHash_1_1 {
 
     private static <T> long naHashLen33To64(Access<T> access, T in, long off, long len) {
         long mul = mul(len);
-        long a = fetch64(access, in, off) * K2;
-        long b = fetch64(access, in, off + 8L);
-        long c = fetch64(access, in, off + len - 8) * mul;
-        long d = fetch64(access, in, off + len - 16) * K2;
+        long a = access.i64(in, off) * K2;
+        long b = access.i64(in, off + 8L);
+        long c = access.i64(in, off + len - 8) * mul;
+        long d = access.i64(in, off + len - 16) * K2;
         long y = rotateRight(a + b, 43) + rotateRight(c, 30) + d;
         long z = hashLen16(y, a + rotateRight(b + K2, 18) + c, mul);
-        long e = fetch64(access, in, off + 16) * mul;
-        long f = fetch64(access, in, off + 24);
-        long g = (y + fetch64(access, in, off + len - 32)) * mul;
-        long h = (z + fetch64(access, in, off + len - 24)) * mul;
+        long e = access.i64(in, off + 16) * mul;
+        long f = access.i64(in, off + 24);
+        long g = (y + access.i64(in, off + len - 32)) * mul;
+        long h = (z + access.i64(in, off + len - 24)) * mul;
         return hashLen16(rotateRight(e + f, 43) + rotateRight(g, 30) + h,
                 e + rotateRight(f + a, 18) + g, mul);
     }
@@ -371,37 +361,37 @@ class CityAndFarmHash_1_1 {
         long z = shiftMix(y * K2 + 113) * K2;
         long v1 = 0, v2 = 0;
         long w1 = 0, w2 = 0;
-        x = x * K2 + fetch64(access, in, off);
+        x = x * K2 + access.i64(in, off);
 
         // Set end so that after the loop we have 1 to 64 bytes left to process.
         long end = off + ((len - 1) >> 6) * 64;
         long last64 = end + ((len - 1) & 63) - 63;
 
         do {
-            x = rotateRight(x + y + v1 + fetch64(access, in, off + 8), 37) * K1;
-            y = rotateRight(y + v2 + fetch64(access, in, off + 48), 42) * K1;
+            x = rotateRight(x + y + v1 + access.i64(in, off + 8), 37) * K1;
+            y = rotateRight(y + v2 + access.i64(in, off + 48), 42) * K1;
             x ^= w2;
-            y += v1 + fetch64(access, in, off + 40);
+            y += v1 + access.i64(in, off + 40);
             z = rotateRight(z + w1, 33) * K1;
             long a = v2 * K1;
             long b = x + w1;
-            long z1 = fetch64(access, in, off + 24);
-            a += fetch64(access, in, off);
+            long z1 = access.i64(in, off + 24);
+            a += access.i64(in, off);
             b = rotateRight(b + a + z1, 21);
             long c = a;
-            a += fetch64(access, in, off + 8);
-            a += fetch64(access, in, off + 16);
+            a += access.i64(in, off + 8);
+            a += access.i64(in, off + 16);
             b += rotateRight(a, 44);
             v1 = a + z1;
             v2 = b + c;
             long a1 = z + w2;
-            long b1 = y + fetch64(access, in, off + 16);
-            long z2 = fetch64(access, in, off + 32 + 24);
-            a1 += fetch64(access, in, off + 32);
+            long b1 = y + access.i64(in, off + 16);
+            long z2 = access.i64(in, off + 32 + 24);
+            a1 += access.i64(in, off + 32);
             b1 = rotateRight(b1 + a1 + z2, 21);
             long c1 = a1;
-            a1 += fetch64(access, in, off + 32 + 8);
-            a1 += fetch64(access, in, off + 32 + 16);
+            a1 += access.i64(in, off + 32 + 8);
+            a1 += access.i64(in, off + 32 + 16);
             b1 += rotateRight(a1, 44);
             w1 = a1 + z2;
             w2 = b1 + c1;
@@ -418,30 +408,30 @@ class CityAndFarmHash_1_1 {
         w1 += (len - 1) & 63;
         v1 += w1;
         w1 += v1;
-        x = rotateRight(x + y + v1 + fetch64(access, in, off + 8), 37) * mul;
-        y = rotateRight(y + v2 + fetch64(access, in, off + 48), 42) * mul;
+        x = rotateRight(x + y + v1 + access.i64(in, off + 8), 37) * mul;
+        y = rotateRight(y + v2 + access.i64(in, off + 48), 42) * mul;
         x ^= w2 * 9;
-        y += v1 * 9 + fetch64(access, in, off + 40);
+        y += v1 * 9 + access.i64(in, off + 40);
         z = rotateRight(z + w1, 33) * mul;
         long a = v2 * mul;
         long b = x + w1;
-        long z1 = fetch64(access, in, off + 24);
-        a += fetch64(access, in, off);
+        long z1 = access.i64(in, off + 24);
+        a += access.i64(in, off);
         b = rotateRight(b + a + z1, 21);
         long c = a;
-        a += fetch64(access, in, off + 8);
-        a += fetch64(access, in, off + 16);
+        a += access.i64(in, off + 8);
+        a += access.i64(in, off + 16);
         b += rotateRight(a, 44);
         v1 = a + z1;
         v2 = b + c;
         long a1 = z + w2;
-        long b1 = y + fetch64(access, in, off + 16);
-        long z2 = fetch64(access, in, off + 32 + 24);
-        a1 += fetch64(access, in, off + 32);
+        long b1 = y + access.i64(in, off + 16);
+        long z2 = access.i64(in, off + 32 + 24);
+        a1 += access.i64(in, off + 32);
         b1 = rotateRight(b1 + a1 + z2, 21);
         long c1 = a1;
-        a1 += fetch64(access, in, off + 32 + 8);
-        a1 += fetch64(access, in, off + 32 + 16);
+        a1 += access.i64(in, off + 32 + 8);
+        a1 += access.i64(in, off + 32 + 16);
         b1 += rotateRight(a1, 44);
         w1 = a1 + z2;
         w2 = b1 + c1;
@@ -484,14 +474,14 @@ class CityAndFarmHash_1_1 {
         long last64 = end + ((len - 1) & 63) - 63;
 
         do {
-            long a0 = fetch64(access, in, off);
-            long a1 = fetch64(access, in, off + 8);
-            long a2 = fetch64(access, in, off + 16);
-            long a3 = fetch64(access, in, off + 24);
-            long a4 = fetch64(access, in, off + 32);
-            long a5 = fetch64(access, in, off + 40);
-            long a6 = fetch64(access, in, off + 48);
-            long a7 = fetch64(access, in, off + 56);
+            long a0 = access.i64(in, off);
+            long a1 = access.i64(in, off + 8);
+            long a2 = access.i64(in, off + 16);
+            long a3 = access.i64(in, off + 24);
+            long a4 = access.i64(in, off + 32);
+            long a5 = access.i64(in, off + 40);
+            long a6 = access.i64(in, off + 48);
+            long a7 = access.i64(in, off + 56);
             x += a0 + a1;
             y += a2;
             z += a3;
@@ -547,32 +537,32 @@ class CityAndFarmHash_1_1 {
         w0 += (len - 1) & 63;
         u += y;
         y += u;
-        x = rotateRight(y - x + v0 + fetch64(access, in, off + 8), 37) * mul;
-        y = rotateRight(y ^ v1 ^ fetch64(access, in, off + 48), 42) * mul;
+        x = rotateRight(y - x + v0 + access.i64(in, off + 8), 37) * mul;
+        y = rotateRight(y ^ v1 ^ access.i64(in, off + 48), 42) * mul;
         x ^= w1 * 9;
-        y += v0 + fetch64(access, in, off + 40);
+        y += v0 + access.i64(in, off + 40);
         z = rotateRight(z + w0, 33) * mul;
 
         long a = v1 * mul;
         long b = x + w0;
-        long z1 = fetch64(access, in, off + 24);
-        a += fetch64(access, in, off);
+        long z1 = access.i64(in, off + 24);
+        a += access.i64(in, off);
         b = rotateRight(b + a + z1, 21);
         long c = a;
-        a += fetch64(access, in, off + 8);
-        a += fetch64(access, in, off + 16);
+        a += access.i64(in, off + 8);
+        a += access.i64(in, off + 16);
         b += rotateRight(a, 44);
         v0 =  a + z1;
         v1 = b + c;
 
         long a1 = z + w1;
-        long b1 = y + fetch64(access, in, off + 16);
-        long z2 = fetch64(access, in, off + 32 + 24);
-        a1 += fetch64(access, in, off + 32);
+        long b1 = y + access.i64(in, off + 16);
+        long z2 = access.i64(in, off + 32 + 24);
+        a1 += access.i64(in, off + 32);
         b1 = rotateRight(b1 + a1 + z2, 21);
         long c1 = a1;
-        a1 += fetch64(access, in, off + 32 + 8);
-        a1 += fetch64(access, in, off + 32 + 16);
+        a1 += access.i64(in, off + 32 + 8);
+        a1 += access.i64(in, off + 32 + 16);
         b1 += rotateRight(a1, 44);
         w0 = a1 + z2;
         w1 = b1 + c1;

--- a/src/main/java/net/openhft/hashing/CityAndFarmHash_1_1.java
+++ b/src/main/java/net/openhft/hashing/CityAndFarmHash_1_1.java
@@ -83,14 +83,6 @@ class CityAndFarmHash_1_1 {
         return access.getInt(in, off);
     }
 
-    long toLittleEndian(long v) {
-        return v;
-    }
-
-    int toLittleEndian(int v) {
-        return v;
-    }
-
     private <T> long hashLen0To16(Access<T> access, T in, long off, long len) {
         if (len >= 8L) {
             long a = fetch64(access, in, off);
@@ -254,16 +246,6 @@ class CityAndFarmHash_1_1 {
         <T> int fetch32(Access<T> access, T in, long off) {
             return Integer.reverseBytes(super.fetch32(access, in, off));
         }
-
-        @Override
-        long toLittleEndian(long v) {
-            return reverseBytes(v);
-        }
-
-        @Override
-        int toLittleEndian(int v) {
-            return Integer.reverseBytes(v);
-        }
     }
 
     private static class AsLongHashFunction extends LongHashFunction {
@@ -276,14 +258,14 @@ class CityAndFarmHash_1_1 {
 
         @Override
         public long hashLong(long input) {
-            input = NATIVE_CITY.toLittleEndian(input);
+            input = Primitives.nativeToLittleEndian(input);
             long hash = hash8To16Bytes(8L, input, input);
             return finalize(hash);
         }
 
         @Override
         public long hashInt(int input) {
-            input = NATIVE_CITY.toLittleEndian(input);
+            input = Primitives.nativeToLittleEndian(input);
             long unsignedInt = Primitives.unsignedInt(input);
             long hash = hash4To7Bytes(4L, unsignedInt, unsignedInt);
             return finalize(hash);

--- a/src/main/java/net/openhft/hashing/CompactLatin1CharSequenceAccess.java
+++ b/src/main/java/net/openhft/hashing/CompactLatin1CharSequenceAccess.java
@@ -80,6 +80,9 @@ class CompactLatin1CharSequenceAccess extends Access<byte[]> {
     static final Access<byte[]> INSTANCE = new CompactLatin1CharSequenceAccess();
 
     @NotNull
+    private static final Access<byte[]> INSTANCE_NON_NATIVE = Access.newDefaultReverseAccess(INSTANCE);
+
+    @NotNull
     private static final UnsafeAccess UNSAFE = UnsafeAccess.INSTANCE;
 
     private static final long UNSAFE_IDX_ADJUST
@@ -167,5 +170,11 @@ class CompactLatin1CharSequenceAccess extends Access<byte[]> {
     @NotNull
     public ByteOrder byteOrder(final byte[] input) {
         return UNSAFE.byteOrder(input);
+    }
+
+    @Override
+    @NotNull
+    protected Access<byte[]> reverseAccess() {
+        return INSTANCE_NON_NATIVE;
     }
 }

--- a/src/main/java/net/openhft/hashing/Maths.java
+++ b/src/main/java/net/openhft/hashing/Maths.java
@@ -4,7 +4,7 @@ import org.jetbrains.annotations.NotNull;
 
 class Maths {
     @NotNull
-    static final Maths INSTANCE;
+    private static final Maths INSTANCE;
 
     static {
         boolean hasMultiplyHigh = true;
@@ -16,7 +16,11 @@ class Maths {
         INSTANCE = hasMultiplyHigh ? new MathsJDK9() : new Maths();
     }
 
-    long unsignedLongMulXorFold(final long lhs, final long rhs) {
+    public static long unsignedLongMulXorFold(final long lhs, final long rhs) {
+        return INSTANCE.unsignedLongMulXorFoldImp(lhs, rhs);
+    }
+
+    long unsignedLongMulXorFoldImp(final long lhs, final long rhs) {
         //The Grade School method of multiplication is a hair faster in Java, primarily used here
         // because the implementation is simpler.
         final long lhs_l = lhs & 0xFFFFFFFFL;
@@ -40,7 +44,7 @@ class MathsJDK9 extends Maths {
     // Math.multiplyHigh() is intrinsified from JDK 10. But JDK 9 is out of life, we always prefer
     // this version to the scalar one.
     @Override
-    long unsignedLongMulXorFold(final long lhs, final long rhs) {
+    long unsignedLongMulXorFoldImp(final long lhs, final long rhs) {
         final long upper = Math.multiplyHigh(lhs, rhs) + ((lhs >> 63) & rhs) + ((rhs >> 63) & lhs);
         final long lower = lhs * rhs;
         return lower ^ upper;

--- a/src/main/java/net/openhft/hashing/MetroHash.java
+++ b/src/main/java/net/openhft/hashing/MetroHash.java
@@ -30,18 +30,6 @@ class MetroHash {
         return access.getUnsignedByte(in, off);
     }
 
-    long toLittleEndian(long v) {
-        return v;
-    }
-
-    int toLittleEndian(int v) {
-        return v;
-    }
-
-    short toLittleEndian(short v) {
-        return v;
-    }
-
 
     <T> long metroHash64(long seed, T input, Access<T> access, long off, long length) {
         long remaining = length;
@@ -153,21 +141,6 @@ class MetroHash {
         <T> int fetch8(Access<T> access, T in, long off) {
             return super.fetch8(access, in, off);
         }
-
-        @Override
-        long toLittleEndian(long v) {
-            return Long.reverseBytes(v);
-        }
-
-        @Override
-        int toLittleEndian(int v) {
-            return Integer.reverseBytes(v);
-        }
-
-        @Override
-        short toLittleEndian(short v) {
-            return Short.reverseBytes(v);
-        }
     }
 
     private static class AsLongHashFunction extends LongHashFunction {
@@ -185,7 +158,7 @@ class MetroHash {
 
         @Override
         public long hashLong(long input) {
-            input = NATIVE_METRO.toLittleEndian(input);
+            input = Primitives.nativeToLittleEndian(input);
             long h = (seed() + k2) * k0;
             h += input * k3;
             h ^= Long.rotateRight(h, 55) * k1;
@@ -195,7 +168,7 @@ class MetroHash {
 
         @Override
         public long hashInt(int input) {
-            input = NATIVE_METRO.toLittleEndian(input);
+            input = Primitives.nativeToLittleEndian(input);
             long h = (seed() + k2) * k0;
             h += Primitives.unsignedInt(input) * k3;
             h ^= Long.rotateRight(h, 26) * k1;
@@ -205,7 +178,7 @@ class MetroHash {
 
         @Override
         public long hashShort(short input) {
-            input = NATIVE_METRO.toLittleEndian(input);
+            input = Primitives.nativeToLittleEndian(input);
             long h = (seed() + k2) * k0;
             h += Primitives.unsignedShort(input) * k3;
             h ^= Long.rotateRight(h, 48) * k1;

--- a/src/main/java/net/openhft/hashing/MetroHash.java
+++ b/src/main/java/net/openhft/hashing/MetroHash.java
@@ -10,23 +10,6 @@ class MetroHash {
     private static final long k2 = 0x62992FC1L;
     private static final long k3 = 0x30BC5B29L;
 
-    static <T> long fetch64(Access<T> access, T in, long off) {
-        return access.getLong(in, off);
-    }
-
-    static <T> long fetch32(Access<T> access, T in, long off) {
-        return access.getUnsignedInt(in, off);
-    }
-
-    static <T> long fetch16(Access<T> access, T in, long off) {
-        return access.getUnsignedShort(in, off);
-    }
-
-    static <T> int fetch8(Access<T> access, T in, long off) {
-        return access.getUnsignedByte(in, off);
-    }
-
-
     static <T> long metroHash64(long seed, T input, Access<T> access, long off, long length) {
         long remaining = length;
 
@@ -39,13 +22,13 @@ class MetroHash {
             long v3 = h;
 
             do {
-                v0 += fetch64(access, input, off) * k0;
+                v0 += access.i64(input, off) * k0;
                 v0 = Long.rotateRight(v0, 29) + v2;
-                v1 += fetch64(access, input, off + 8) * k1;
+                v1 += access.i64(input, off + 8) * k1;
                 v1 = Long.rotateRight(v1, 29) + v3;
-                v2 += fetch64(access, input, off + 16) * k2;
+                v2 += access.i64(input, off + 16) * k2;
                 v2 = Long.rotateRight(v2, 29) + v0;
-                v3 += fetch64(access, input, off + 24) * k3;
+                v3 += access.i64(input, off + 24) * k3;
                 v3 = Long.rotateRight(v3, 29) + v1;
 
                 off += 32;
@@ -61,9 +44,9 @@ class MetroHash {
         }
 
         if (remaining >= 16) {
-            long v0 = h + (fetch64(access, input, off) * k2);
+            long v0 = h + (access.i64(input, off) * k2);
             v0 = Long.rotateRight(v0, 29) * k3;
-            long v1 = h + (fetch64(access, input, off + 8) * k2);
+            long v1 = h + (access.i64(input, off + 8) * k2);
             v1 = Long.rotateRight(v1, 29) * k3;
             v0 ^= Long.rotateRight(v0 * k0, 21) + v1;
             v1 ^= Long.rotateRight(v1 * k3, 21) + v0;
@@ -74,7 +57,7 @@ class MetroHash {
         }
 
         if (remaining >= 8) {
-            h += fetch64(access, input, off) * k3;
+            h += access.i64(input, off) * k3;
             h ^= Long.rotateRight(h, 55) * k1;
 
             off += 8;
@@ -82,7 +65,7 @@ class MetroHash {
         }
 
         if (remaining >= 4) {
-            h += fetch32(access, input, off) * k3;
+            h += access.u32(input, off) * k3;
             h ^= Long.rotateRight(h, 26) * k1;
 
             off += 4;
@@ -90,7 +73,7 @@ class MetroHash {
         }
 
         if (remaining >= 2) {
-            h += fetch16(access, input, off) * k3;
+            h += access.u16(input, off) * k3;
             h ^= Long.rotateRight(h, 48) * k1;
 
             off += 2;
@@ -98,7 +81,7 @@ class MetroHash {
         }
 
         if (remaining >= 1) {
-            h += fetch8(access, input, off) * k3;
+            h += access.u8(input, off) * k3;
             h ^= Long.rotateRight(h, 37) * k1;
         }
 

--- a/src/main/java/net/openhft/hashing/MurmurHash_3.java
+++ b/src/main/java/net/openhft/hashing/MurmurHash_3.java
@@ -32,27 +32,20 @@ import static net.openhft.hashing.Primitives.unsignedShort;
  */
 @ParametersAreNonnullByDefault
 class MurmurHash_3 {
-    @NotNull
-    private static final MurmurHash_3 INSTANCE = new MurmurHash_3();
-
-    @NotNull
-    private static final MurmurHash_3 NATIVE_MURMUR = NATIVE_LITTLE_ENDIAN ?
-            MurmurHash_3.INSTANCE : BigEndian.INSTANCE;
-
     private static final long C1 = 0x87c37b91114253d5L;
     private static final long C2 = 0x4cf5ad432745937fL;
 
     private MurmurHash_3() {}
 
-    <T> long fetch64(Access<T> access, @Nullable T in, long off) {
+    private static <T> long fetch64(Access<T> access, @Nullable T in, long off) {
         return access.getLong(in, off);
     }
 
-    <T> int fetch32(Access<T> access, @Nullable T in, long off) {
+    private static <T> int fetch32(Access<T> access, @Nullable T in, long off) {
         return access.getInt(in, off);
     }
 
-    public <T> long hash(long seed, @Nullable T input, Access<T> access, long offset, long length, @Nullable long[] result) {
+    private static <T> long hash(long seed, @Nullable T input, Access<T> access, long offset, long length, @Nullable long[] result) {
         long h1 = seed;
         long h2 = seed;
         long remaining = length;
@@ -235,22 +228,6 @@ class MurmurHash_3 {
         return k2;
     }
 
-    private static class BigEndian extends MurmurHash_3 {
-        @NotNull
-        private static final BigEndian INSTANCE = new BigEndian();
-        private BigEndian() {}
-
-        @Override
-        <T> long fetch64(Access<T> access, @Nullable T in, long off) {
-            return reverseBytes(super.fetch64(access, in, off));
-        }
-
-        @Override
-        <T> int fetch32(Access<T> access, @Nullable T in, long off) {
-            return Integer.reverseBytes(super.fetch32(access, in, off));
-        }
-    }
-
     private static class AsLongTupleHashFunction extends DualHashFunction {
         private static final long serialVersionUID = 0L;
         @NotNull
@@ -319,11 +296,7 @@ class MurmurHash_3 {
         @Override
         public <T> long dualHash(@Nullable T input, Access<T> access, long off, long len, @Nullable long[] result) {
             long seed = seed();
-            if (access.byteOrder(input) == LITTLE_ENDIAN) {
-                return MurmurHash_3.INSTANCE.hash(seed, input, access, off, len, result);
-            } else {
-                return BigEndian.INSTANCE.hash(seed, input, access, off, len, result);
-            }
+            return MurmurHash_3.hash(seed, input, access.byteOrder(input, LITTLE_ENDIAN), off, len, result);
         }
     }
 

--- a/src/main/java/net/openhft/hashing/MurmurHash_3.java
+++ b/src/main/java/net/openhft/hashing/MurmurHash_3.java
@@ -35,23 +35,13 @@ class MurmurHash_3 {
     private static final long C1 = 0x87c37b91114253d5L;
     private static final long C2 = 0x4cf5ad432745937fL;
 
-    private MurmurHash_3() {}
-
-    private static <T> long fetch64(Access<T> access, @Nullable T in, long off) {
-        return access.getLong(in, off);
-    }
-
-    private static <T> int fetch32(Access<T> access, @Nullable T in, long off) {
-        return access.getInt(in, off);
-    }
-
     private static <T> long hash(long seed, @Nullable T input, Access<T> access, long offset, long length, @Nullable long[] result) {
         long h1 = seed;
         long h2 = seed;
         long remaining = length;
         while (remaining >= 16L) {
-            long k1 = fetch64(access, input, offset);
-            long k2 = fetch64(access, input, offset + 8L);
+            long k1 = access.i64(input, offset);
+            long k2 = access.i64(input, offset + 8L);
             offset += 16L;
             remaining -= 16L;
             h1 ^= mixK1(k1);
@@ -72,37 +62,37 @@ class MurmurHash_3 {
             long k2 = 0L;
             switch ((int) remaining) {
                 case 15:
-                    k2 ^= ((long) access.getUnsignedByte(input, offset + 14L)) << 48;// fall through
+                    k2 ^= ((long) access.u8(input, offset + 14L)) << 48;// fall through
                 case 14:
-                    k2 ^= ((long) access.getUnsignedByte(input, offset + 13L)) << 40;// fall through
+                    k2 ^= ((long) access.u8(input, offset + 13L)) << 40;// fall through
                 case 13:
-                    k2 ^= ((long) access.getUnsignedByte(input, offset + 12L)) << 32;// fall through
+                    k2 ^= ((long) access.u8(input, offset + 12L)) << 32;// fall through
                 case 12:
-                    k2 ^= ((long) access.getUnsignedByte(input, offset + 11L)) << 24;// fall through
+                    k2 ^= ((long) access.u8(input, offset + 11L)) << 24;// fall through
                 case 11:
-                    k2 ^= ((long) access.getUnsignedByte(input, offset + 10L)) << 16;// fall through
+                    k2 ^= ((long) access.u8(input, offset + 10L)) << 16;// fall through
                 case 10:
-                    k2 ^= ((long) access.getUnsignedByte(input, offset + 9L)) << 8; // fall through
+                    k2 ^= ((long) access.u8(input, offset + 9L)) << 8; // fall through
                 case 9:
-                    k2 ^= ((long) access.getUnsignedByte(input, offset + 8L)); // fall through
+                    k2 ^= ((long) access.u8(input, offset + 8L)); // fall through
                 case 8:
-                    k1 ^= fetch64(access, input, offset);
+                    k1 ^= access.i64(input, offset);
                     break;
                 case 7:
-                    k1 ^= ((long) access.getUnsignedByte(input, offset + 6L)) << 48; // fall through
+                    k1 ^= ((long) access.u8(input, offset + 6L)) << 48; // fall through
                 case 6:
-                    k1 ^= ((long) access.getUnsignedByte(input, offset + 5L)) << 40; // fall through
+                    k1 ^= ((long) access.u8(input, offset + 5L)) << 40; // fall through
                 case 5:
-                    k1 ^= ((long) access.getUnsignedByte(input, offset + 4L)) << 32; // fall through
+                    k1 ^= ((long) access.u8(input, offset + 4L)) << 32; // fall through
                 case 4:
-                    k1 ^= Primitives.unsignedInt(fetch32(access, input, offset));
+                    k1 ^= access.u32(input, offset);
                     break;
                 case 3:
-                    k1 ^= ((long) access.getUnsignedByte(input, offset + 2L)) << 16; // fall through
+                    k1 ^= ((long) access.u8(input, offset + 2L)) << 16; // fall through
                 case 2:
-                    k1 ^= ((long) access.getUnsignedByte(input, offset + 1L)) << 8; // fall through
+                    k1 ^= ((long) access.u8(input, offset + 1L)) << 8; // fall through
                 case 1:
-                    k1 ^= ((long) access.getUnsignedByte(input, offset));
+                    k1 ^= ((long) access.u8(input, offset));
                 case 0:
                     break;
                 default:
@@ -127,54 +117,54 @@ class MurmurHash_3 {
 //                        {
 //                            switch ((int) remaining) {
 //                                case 15:
-//                                    k2 ^= ((long) access.getUnsignedByte(input, offset + 14L)) << 48;
+//                                    k2 ^= ((long) access.u8(input, offset + 14L)) << 48;
 //                                case 14:
 //                                    k2 ^= ((long) Primitives.nativeToLittleEndian(
-//                                            access.getUnsignedShort(input, offset + 12L))) << 32;
+//                                            access.u16(input, offset + 12L))) << 32;
 //                                    break fetch8_11;
 //                                case 13:
-//                                    k2 ^= ((long) access.getUnsignedByte(input, offset + 12L)) << 32;
+//                                    k2 ^= ((long) access.u8(input, offset + 12L)) << 32;
 //                                case 12:
 //                                    break fetch8_11;
 //                                case 11:
-//                                    k2 ^= ((long) access.getUnsignedByte(input, offset + 10L)) << 16;
+//                                    k2 ^= ((long) access.u8(input, offset + 10L)) << 16;
 //                                case 10:
 //                                    k2 ^= (long) Primitives.nativeToLittleEndian(
-//                                            access.getUnsignedShort(input, offset + 8L));
+//                                            access.u16(input, offset + 8L));
 //                                    break fetch0_7;
 //                                case 9:
-//                                    k2 ^= ((long) access.getUnsignedByte(input, offset + 8L));
+//                                    k2 ^= ((long) access.u8(input, offset + 8L));
 //                                case 8:
 //                                    break fetch0_7;
 //                                case 7:
-//                                    k1 ^= ((long) access.getUnsignedByte(input, offset + 6L)) << 48;
+//                                    k1 ^= ((long) access.u8(input, offset + 6L)) << 48;
 //                                case 6:
 //                                    k1 ^= ((long) Primitives.nativeToLittleEndian(
-//                                            access.getUnsignedShort(input, offset + 4L))) << 32;
+//                                            access.u16(input, offset + 4L))) << 32;
 //                                    break fetch0_3;
 //                                case 5:
-//                                    k1 ^= ((long) access.getUnsignedByte(input, offset + 4L)) << 32;
+//                                    k1 ^= ((long) access.u8(input, offset + 4L)) << 32;
 //                                case 4:
 //                                    break fetch0_3;
 //                                case 3:
-//                                    k1 ^= ((long) access.getUnsignedByte(input, offset + 2L)) << 16;
+//                                    k1 ^= ((long) access.u8(input, offset + 2L)) << 16;
 //                                case 2:
 //                                    k1 ^= (long) Primitives.nativeToLittleEndian(
-//                                            access.getUnsignedShort(input, offset));
+//                                            access.u16(input, offset));
 //                                    break megaSwitch;
 //                                case 1:
-//                                    k1 ^= ((long) access.getUnsignedByte(input, offset));
+//                                    k1 ^= ((long) access.u8(input, offset));
 //                                    break megaSwitch;
 //                                default:
 //                                    throw new AssertionError();
 //                            }
 //                        } // fetch0_3
-//                        k1 ^= unsignedInt(fetch32(access, input, offset));
+//                        k1 ^= access.u32(input, offset);
 //                        break megaSwitch;
 //                    } // fetch8_11
-//                    k2 ^= unsignedInt(fetch32(access, input, offset + 8L));
+//                    k2 ^= access.u32(input, offset + 8L);
 //                } // fetch0_7
-//                k1 ^= fetch64(access, input, offset);
+//                k1 ^= access.i64(input, offset);
 //            } // megaSwitch
 //
 //            h1 ^= mixK1(k1);

--- a/src/main/java/net/openhft/hashing/MurmurHash_3.java
+++ b/src/main/java/net/openhft/hashing/MurmurHash_3.java
@@ -24,6 +24,7 @@ import static java.lang.Long.reverseBytes;
 import static java.nio.ByteOrder.LITTLE_ENDIAN;
 import static net.openhft.hashing.Util.NATIVE_LITTLE_ENDIAN;
 import static net.openhft.hashing.Primitives.unsignedInt;
+import static net.openhft.hashing.Primitives.unsignedShort;
 
 /**
  * Derived from https://github.com/google/guava/blob/fa95e381e665d8ee9639543b99ed38020c8de5ef
@@ -49,18 +50,6 @@ class MurmurHash_3 {
 
     <T> int fetch32(Access<T> access, @Nullable T in, long off) {
         return access.getInt(in, off);
-    }
-
-    long toLittleEndian(long v) {
-        return v;
-    }
-
-    int toLittleEndian(int v) {
-        return v;
-    }
-
-    int toLittleEndianShort(int unsignedShort) {
-        return unsignedShort;
     }
 
     public <T> long hash(long seed, @Nullable T input, Access<T> access, long offset, long length, @Nullable long[] result) {
@@ -147,7 +136,7 @@ class MurmurHash_3 {
 //                                case 15:
 //                                    k2 ^= ((long) access.getUnsignedByte(input, offset + 14L)) << 48;
 //                                case 14:
-//                                    k2 ^= ((long) toLittleEndianShort(
+//                                    k2 ^= ((long) Primitives.nativeToLittleEndian(
 //                                            access.getUnsignedShort(input, offset + 12L))) << 32;
 //                                    break fetch8_11;
 //                                case 13:
@@ -157,7 +146,7 @@ class MurmurHash_3 {
 //                                case 11:
 //                                    k2 ^= ((long) access.getUnsignedByte(input, offset + 10L)) << 16;
 //                                case 10:
-//                                    k2 ^= (long) toLittleEndianShort(
+//                                    k2 ^= (long) Primitives.nativeToLittleEndian(
 //                                            access.getUnsignedShort(input, offset + 8L));
 //                                    break fetch0_7;
 //                                case 9:
@@ -167,7 +156,7 @@ class MurmurHash_3 {
 //                                case 7:
 //                                    k1 ^= ((long) access.getUnsignedByte(input, offset + 6L)) << 48;
 //                                case 6:
-//                                    k1 ^= ((long) toLittleEndianShort(
+//                                    k1 ^= ((long) Primitives.nativeToLittleEndian(
 //                                            access.getUnsignedShort(input, offset + 4L))) << 32;
 //                                    break fetch0_3;
 //                                case 5:
@@ -177,7 +166,7 @@ class MurmurHash_3 {
 //                                case 3:
 //                                    k1 ^= ((long) access.getUnsignedByte(input, offset + 2L)) << 16;
 //                                case 2:
-//                                    k1 ^= (long) toLittleEndianShort(
+//                                    k1 ^= (long) Primitives.nativeToLittleEndian(
 //                                            access.getUnsignedShort(input, offset));
 //                                    break megaSwitch;
 //                                case 1:
@@ -260,21 +249,6 @@ class MurmurHash_3 {
         <T> int fetch32(Access<T> access, @Nullable T in, long off) {
             return Integer.reverseBytes(super.fetch32(access, in, off));
         }
-
-        @Override
-        long toLittleEndian(long v) {
-            return reverseBytes(v);
-        }
-
-        @Override
-        int toLittleEndian(int v) {
-            return Integer.reverseBytes(v);
-        }
-
-        @Override
-        int toLittleEndianShort(int unsignedShort) {
-            return ((unsignedShort & 0xFF) << 8) | (unsignedShort >> 8);
-        }
     }
 
     private static class AsLongTupleHashFunction extends DualHashFunction {
@@ -310,28 +284,27 @@ class MurmurHash_3 {
 
         @Override
         public long dualHashLong(long input, @Nullable long[] result) {
-            return hashNativeLong(NATIVE_MURMUR.toLittleEndian(input), 8L, result);
+            return hashNativeLong(Primitives.nativeToLittleEndian(input), 8L, result);
         }
 
         @Override
         public long dualHashInt(int input, @Nullable long[] result) {
-            return hashNativeLong(unsignedInt(NATIVE_MURMUR.toLittleEndian(input)), 4L, result);
+            return hashNativeLong(unsignedInt(Primitives.nativeToLittleEndian(input)), 4L, result);
         }
 
         @Override
         public long dualHashShort(short input, @Nullable long[] result) {
-            return hashNativeLong(
-                    (long) NATIVE_MURMUR.toLittleEndianShort(Primitives.unsignedShort(input)), 2L, result);
+            return hashNativeLong(unsignedShort(Primitives.nativeToLittleEndian(input)), 2L, result);
         }
 
         @Override
         public long dualHashChar(char input, @Nullable long[] result) {
-            return hashNativeLong((long) NATIVE_MURMUR.toLittleEndianShort((int) input), 2L, result);
+            return hashNativeLong(unsignedShort(Primitives.nativeToLittleEndian(input)), 2L, result);
         }
 
         @Override
         public long dualHashByte(byte input, @Nullable long[] result) {
-            return hashNativeLong((long) Primitives.unsignedByte((int) input), 1L, result);
+            return hashNativeLong(Primitives.unsignedByte((int) input), 1L, result);
         }
 
         @Override

--- a/src/main/java/net/openhft/hashing/Primitives.java
+++ b/src/main/java/net/openhft/hashing/Primitives.java
@@ -16,6 +16,8 @@
 
 package net.openhft.hashing;
 
+import static net.openhft.hashing.Util.NATIVE_LITTLE_ENDIAN;
+
 final class Primitives {
 
     private Primitives() {}
@@ -30,5 +32,31 @@ final class Primitives {
 
     static int unsignedByte(int b) {
         return b & 0xFF;
+    }
+
+    private static final ByteOrderHelper H2LE = NATIVE_LITTLE_ENDIAN ? new ByteOrderHelper() : new ByteOrderHelperReverse();
+    private static final ByteOrderHelper H2BE = NATIVE_LITTLE_ENDIAN ? new ByteOrderHelperReverse() : new ByteOrderHelper();
+
+    static long nativeToLittleEndian(final long v) { return H2LE.adjustByteOrder(v); }
+    static int nativeToLittleEndian(final int v) { return H2LE.adjustByteOrder(v); }
+    static short nativeToLittleEndian(final short v) { return H2LE.adjustByteOrder(v); }
+    static char nativeToLittleEndian(final char v) { return H2LE.adjustByteOrder(v); }
+
+    static long nativeToBigEndian(final long v) { return H2BE.adjustByteOrder(v); }
+    static int nativeToBigEndian(final int v) { return H2BE.adjustByteOrder(v); }
+    static short nativeToBigEndian(final short v) { return H2BE.adjustByteOrder(v); }
+    static char nativeToBigEndian(final char v) { return H2BE.adjustByteOrder(v); }
+
+    private static class ByteOrderHelper {
+        long adjustByteOrder(final long v) { return v; }
+        int adjustByteOrder(final int v) { return v; }
+        short adjustByteOrder(final short v) { return v; }
+        char adjustByteOrder(final char v) { return v; }
+    }
+    private static class ByteOrderHelperReverse extends ByteOrderHelper {
+        long adjustByteOrder(final long v) { return Long.reverseBytes(v); }
+        int adjustByteOrder(final int v) { return Integer.reverseBytes(v); }
+        short adjustByteOrder(final short v) { return Short.reverseBytes(v); }
+        char adjustByteOrder(final char v) { return Character.reverseBytes(v); }
     }
 }

--- a/src/main/java/net/openhft/hashing/UnsafeAccess.java
+++ b/src/main/java/net/openhft/hashing/UnsafeAccess.java
@@ -25,6 +25,7 @@ import static net.openhft.hashing.Util.NATIVE_LITTLE_ENDIAN;
 
 class UnsafeAccess extends Access<Object> {
     static final UnsafeAccess INSTANCE;
+    private static final Access<Object> INSTANCE_NON_NATIVE;
 
     // for test only
     static final UnsafeAccess OLD_INSTANCE = NATIVE_LITTLE_ENDIAN
@@ -73,6 +74,7 @@ class UnsafeAccess extends Access<Object> {
         }
 
         INSTANCE = hasGetByte ? new UnsafeAccess() : OLD_INSTANCE;
+        INSTANCE_NON_NATIVE = Access.newDefaultReverseAccess(INSTANCE);
     }
 
     private UnsafeAccess() {}
@@ -115,6 +117,11 @@ class UnsafeAccess extends Access<Object> {
     @Override
     public ByteOrder byteOrder(Object input) {
         return ByteOrder.nativeOrder();
+    }
+
+    @Override
+    protected Access<Object> reverseAccess() {
+        return INSTANCE_NON_NATIVE;
     }
 
     private static class OldUnsafeAccessLittleEndian extends UnsafeAccess {

--- a/src/main/java/net/openhft/hashing/WyHash.java
+++ b/src/main/java/net/openhft/hashing/WyHash.java
@@ -51,18 +51,6 @@ class WyHash {
     private WyHash() {
     }
 
-    long toLittleEndian(long v) {
-        return v;
-    }
-
-    int toLittleEndian(int v) {
-        return v;
-    }
-
-    short toLittleEndian(short v) {
-        return v;
-    }
-
     /**
      *
      * @param seed seed for the hash
@@ -174,21 +162,6 @@ class WyHash {
         <T> long _wyr4(Access<T> access, T in, long off) {
             return Primitives.unsignedInt(Integer.reverseBytes(access.getInt(in, off)));
         }
-
-        @Override
-        long toLittleEndian(long v) {
-            return Long.reverseBytes(v);
-        }
-
-        @Override
-        int toLittleEndian(int v) {
-            return Integer.reverseBytes(v);
-        }
-
-        @Override
-        short toLittleEndian(short v) {
-            return Short.reverseBytes(v);
-        }
     }
 
 
@@ -210,7 +183,7 @@ class WyHash {
 
         @Override
         public long hashLong(long input) {
-            input = NATIVE_WY.toLittleEndian(input);
+            input = Primitives.nativeToLittleEndian(input);
             long hi = input & 0xFFFFFFFFL;
             long lo = (input >>> 32) & 0xFFFFFFFFL;
             return _wymum(_wymum(hi ^ seed() ^ _wyp0,
@@ -220,7 +193,7 @@ class WyHash {
 
         @Override
         public long hashInt(int input) {
-            input = NATIVE_WY.toLittleEndian(input);
+            input = Primitives.nativeToLittleEndian(input);
             long longInput = (input & 0xFFFFFFFFL);
             return _wymum(_wymum(longInput ^ seed() ^ _wyp0,
                                  longInput ^ seed() ^ _wyp1)
@@ -229,7 +202,7 @@ class WyHash {
 
         @Override
         public long hashShort(short input) {
-            input = NATIVE_WY.toLittleEndian(input);
+            input = Primitives.nativeToLittleEndian(input);
             long hi = (input >>> 8) & 0xFFL;
             long wyr3 = hi | hi << 8 | (input & 0xFFL) << 16;
             return _wymum(_wymum(wyr3 ^ seed() ^ _wyp0,

--- a/src/main/java/net/openhft/hashing/WyHash.java
+++ b/src/main/java/net/openhft/hashing/WyHash.java
@@ -25,26 +25,14 @@ class WyHash {
         return MATHS.unsignedLongMulXorFold(lhs, rhs);
     }
 
-    static <T> long _wyr8(final Access<T> access, T in, final long index) {
-        return access.getLong(in, index);
-    }
-
-    static <T> long _wyr4(final Access<T> access, T in, final long index) {
-        return access.getUnsignedInt(in, index);
-    }
-
     private static <T> long _wyr3(final Access<T> access, T in, final long index, long k) {
-        return ((long) access.getUnsignedByte(in, index) << 16) |
-               ((long) access.getUnsignedByte(in, index + (k >>> 1)) << 8) |
-               ((long) access.getUnsignedByte(in, index + k - 1));
+        return ((long) access.u8(in, index) << 16) |
+               ((long) access.u8(in, index + (k >>> 1)) << 8) |
+               ((long) access.u8(in, index + k - 1));
     }
 
-    private static <T> long __wyr8(final Access<T> access, T in, final long index) {
-        return (_wyr4(access, in, index) << 32) |
-               _wyr4(access, in, index + 4);
-    }
-
-    private WyHash() {
+    private static <T> long u64Rorate32(final Access<T> access, T in, final long index) {
+        return (access.u32(in, index) << 32) | access.u32(in, index + 4);
     }
 
     /**
@@ -64,81 +52,81 @@ class WyHash {
             return _wymum(_wymum(_wyr3(access, input,off,length)^seed^_wyp0,
                                  seed^_wyp1)^seed,length^_wyp4);
         else if(length<=8)
-            return _wymum(_wymum(_wyr4(access, input, off) ^ seed ^ _wyp0,
-                                 _wyr4(access, input, off + length - 4) ^ seed ^ _wyp1)
+            return _wymum(_wymum(access.u32(input, off) ^ seed ^ _wyp0,
+                                 access.u32(input, off + length - 4) ^ seed ^ _wyp1)
                           ^ seed, length ^ _wyp4);
         else if(length<=16)
-            return _wymum(_wymum(__wyr8(access, input,off)^seed^_wyp0,
-                                 __wyr8(access, input,off+length-8)^seed^_wyp1)
+            return _wymum(_wymum(u64Rorate32(access, input,off)^seed^_wyp0,
+                                 u64Rorate32(access, input,off+length-8)^seed^_wyp1)
                           ^seed,length^_wyp4);
         else if(length<=24)
-            return _wymum(_wymum(__wyr8(access, input,off)^seed^_wyp0,
-                                 __wyr8(access, input,off+8)^seed^_wyp1)^
-                          _wymum(__wyr8(access, input,off+length-8)
+            return _wymum(_wymum(u64Rorate32(access, input,off)^seed^_wyp0,
+                                 u64Rorate32(access, input,off+8)^seed^_wyp1)^
+                          _wymum(u64Rorate32(access, input,off+length-8)
                                  ^seed^_wyp2,seed^_wyp3),length^_wyp4);
         else if(length<=32)
-            return _wymum(_wymum(__wyr8(access, input,off)^seed^_wyp0,
-                                 __wyr8(access, input,off+8)^seed^_wyp1)
-                          ^_wymum(__wyr8(access, input,off+16)^seed^_wyp2,
-                                  __wyr8(access, input,off+length-8)^seed^_wyp3),length^_wyp4);
+            return _wymum(_wymum(u64Rorate32(access, input,off)^seed^_wyp0,
+                                 u64Rorate32(access, input,off+8)^seed^_wyp1)
+                          ^_wymum(u64Rorate32(access, input,off+16)^seed^_wyp2,
+                                  u64Rorate32(access, input,off+length-8)^seed^_wyp3),length^_wyp4);
         long see1=seed; long i=length, p=off;
         for(;i>256;i-=256,p+=256){
-            seed = _wymum(_wyr8(access, input, p) ^ seed ^ _wyp0,
-                          _wyr8(access, input, p + 8) ^ seed ^ _wyp1) ^
-                   _wymum(_wyr8(access, input, p + 16) ^ seed ^ _wyp2,
-                          _wyr8(access, input, p + 24) ^ seed ^ _wyp3);
-            see1 = _wymum(_wyr8(access, input, p + 32) ^ see1 ^ _wyp1,
-                          _wyr8(access, input, p + 40) ^ see1 ^ _wyp2) ^
-                   _wymum(_wyr8(access, input, p + 48) ^ see1 ^ _wyp3,
-                          _wyr8(access, input, p + 56) ^ see1 ^ _wyp0);
-            seed = _wymum(_wyr8(access, input, p + 64) ^ seed ^ _wyp0,
-                          _wyr8(access, input, p + 72) ^ seed ^ _wyp1) ^
-                   _wymum(_wyr8(access, input, p + 80) ^ seed ^ _wyp2,
-                          _wyr8(access, input, p + 88) ^ seed ^ _wyp3);
-            see1 = _wymum(_wyr8(access, input, p + 96) ^ see1 ^ _wyp1,
-                          _wyr8(access, input, p + 104) ^ see1 ^ _wyp2) ^
-                   _wymum(_wyr8(access, input, p + 112) ^ see1 ^ _wyp3,
-                          _wyr8(access, input, p + 120) ^ see1 ^ _wyp0);
-            seed = _wymum(_wyr8(access, input, p + 128) ^ seed ^ _wyp0,
-                          _wyr8(access, input, p + 136) ^ seed ^ _wyp1) ^
-                   _wymum(_wyr8(access, input, p + 144) ^ seed ^ _wyp2,
-                          _wyr8(access, input, p + 152) ^ seed ^ _wyp3);
-            see1 = _wymum(_wyr8(access, input, p + 160) ^ see1 ^ _wyp1,
-                          _wyr8(access, input, p + 168) ^ see1 ^ _wyp2) ^
-                   _wymum(_wyr8(access, input, p + 176) ^ see1 ^ _wyp3,
-                          _wyr8(access, input, p + 184) ^ see1 ^ _wyp0);
-            seed = _wymum(_wyr8(access, input, p + 192) ^ seed ^ _wyp0,
-                          _wyr8(access, input, p + 200) ^ seed ^ _wyp1) ^
-                   _wymum(_wyr8(access, input, p + 208) ^ seed ^ _wyp2,
-                          _wyr8(access, input, p + 216) ^ seed ^ _wyp3);
-            see1 = _wymum(_wyr8(access, input, p + 224) ^ see1 ^ _wyp1,
-                          _wyr8(access, input, p + 232) ^ see1 ^ _wyp2) ^
-                   _wymum(_wyr8(access, input, p + 240) ^ see1 ^ _wyp3,
-                          _wyr8(access, input, p + 248) ^ see1 ^ _wyp0);
+            seed = _wymum(access.i64(input, p) ^ seed ^ _wyp0,
+                          access.i64(input, p + 8) ^ seed ^ _wyp1) ^
+                   _wymum(access.i64(input, p + 16) ^ seed ^ _wyp2,
+                          access.i64(input, p + 24) ^ seed ^ _wyp3);
+            see1 = _wymum(access.i64(input, p + 32) ^ see1 ^ _wyp1,
+                          access.i64(input, p + 40) ^ see1 ^ _wyp2) ^
+                   _wymum(access.i64(input, p + 48) ^ see1 ^ _wyp3,
+                          access.i64(input, p + 56) ^ see1 ^ _wyp0);
+            seed = _wymum(access.i64(input, p + 64) ^ seed ^ _wyp0,
+                          access.i64(input, p + 72) ^ seed ^ _wyp1) ^
+                   _wymum(access.i64(input, p + 80) ^ seed ^ _wyp2,
+                          access.i64(input, p + 88) ^ seed ^ _wyp3);
+            see1 = _wymum(access.i64(input, p + 96) ^ see1 ^ _wyp1,
+                          access.i64(input, p + 104) ^ see1 ^ _wyp2) ^
+                   _wymum(access.i64(input, p + 112) ^ see1 ^ _wyp3,
+                          access.i64(input, p + 120) ^ see1 ^ _wyp0);
+            seed = _wymum(access.i64(input, p + 128) ^ seed ^ _wyp0,
+                          access.i64(input, p + 136) ^ seed ^ _wyp1) ^
+                   _wymum(access.i64(input, p + 144) ^ seed ^ _wyp2,
+                          access.i64(input, p + 152) ^ seed ^ _wyp3);
+            see1 = _wymum(access.i64(input, p + 160) ^ see1 ^ _wyp1,
+                          access.i64(input, p + 168) ^ see1 ^ _wyp2) ^
+                   _wymum(access.i64(input, p + 176) ^ see1 ^ _wyp3,
+                          access.i64(input, p + 184) ^ see1 ^ _wyp0);
+            seed = _wymum(access.i64(input, p + 192) ^ seed ^ _wyp0,
+                          access.i64(input, p + 200) ^ seed ^ _wyp1) ^
+                   _wymum(access.i64(input, p + 208) ^ seed ^ _wyp2,
+                          access.i64(input, p + 216) ^ seed ^ _wyp3);
+            see1 = _wymum(access.i64(input, p + 224) ^ see1 ^ _wyp1,
+                          access.i64(input, p + 232) ^ see1 ^ _wyp2) ^
+                   _wymum(access.i64(input, p + 240) ^ see1 ^ _wyp3,
+                          access.i64(input, p + 248) ^ see1 ^ _wyp0);
         }
         for (; i > 32; i -= 32, p += 32) {
-            seed = _wymum(_wyr8(access, input, p) ^ seed ^ _wyp0,
-                          _wyr8(access, input, p + 8) ^ seed ^ _wyp1);
-            see1 = _wymum(_wyr8(access, input, p + 16) ^ see1 ^ _wyp2,
-                          _wyr8(access, input, p + 24) ^ see1 ^ _wyp3);
+            seed = _wymum(access.i64(input, p) ^ seed ^ _wyp0,
+                          access.i64(input, p + 8) ^ seed ^ _wyp1);
+            see1 = _wymum(access.i64(input, p + 16) ^ see1 ^ _wyp2,
+                          access.i64(input, p + 24) ^ see1 ^ _wyp3);
         }
         if (i < 4) {
             seed = _wymum(_wyr3(access, input, p, i) ^ seed ^ _wyp0, seed ^ _wyp1);
         } else if (i <= 8) {
-            seed = _wymum(_wyr4(access, input, p) ^ seed ^ _wyp0,
-                          _wyr4(access, input, p + i - 4) ^ seed ^ _wyp1);
+            seed = _wymum(access.u32(input, p) ^ seed ^ _wyp0,
+                          access.u32(input, p + i - 4) ^ seed ^ _wyp1);
         } else if (i <= 16) {
-            seed = _wymum(__wyr8(access, input, p) ^ seed ^ _wyp0,
-                          __wyr8(access, input, p + i - 8) ^ seed ^ _wyp1);
+            seed = _wymum(u64Rorate32(access, input, p) ^ seed ^ _wyp0,
+                          u64Rorate32(access, input, p + i - 8) ^ seed ^ _wyp1);
         } else if (i <= 24) {
-            seed = _wymum(__wyr8(access, input, p) ^ seed ^ _wyp0,
-                          __wyr8(access, input, p + 8) ^ seed ^ _wyp1);
-            see1 = _wymum(__wyr8(access, input, p + i - 8) ^ see1 ^ _wyp2, see1 ^ _wyp3);
+            seed = _wymum(u64Rorate32(access, input, p) ^ seed ^ _wyp0,
+                          u64Rorate32(access, input, p + 8) ^ seed ^ _wyp1);
+            see1 = _wymum(u64Rorate32(access, input, p + i - 8) ^ see1 ^ _wyp2, see1 ^ _wyp3);
         } else {
-            seed = _wymum(__wyr8(access, input, p) ^ seed ^ _wyp0,
-                          __wyr8(access, input, p + 8) ^ seed ^ _wyp1);
-            see1 = _wymum(__wyr8(access, input, p + 16) ^ see1 ^ _wyp2,
-                          __wyr8(access, input, p + i - 8) ^ see1 ^ _wyp3);
+            seed = _wymum(u64Rorate32(access, input, p) ^ seed ^ _wyp0,
+                          u64Rorate32(access, input, p + 8) ^ seed ^ _wyp1);
+            see1 = _wymum(u64Rorate32(access, input, p + 16) ^ see1 ^ _wyp2,
+                          u64Rorate32(access, input, p + i - 8) ^ see1 ^ _wyp3);
         }
         return _wymum(seed ^ see1, length ^ _wyp4);
     }

--- a/src/main/java/net/openhft/hashing/WyHash.java
+++ b/src/main/java/net/openhft/hashing/WyHash.java
@@ -19,10 +19,8 @@ class WyHash {
     public static final long _wyp3 = 0x589965cc75374cc3L;
     public static final long _wyp4 = 0x1d8e4e27c47d124fL;
 
-    private static final Maths MATHS = Maths.INSTANCE;
-
     private static long _wymum(final long lhs, final long rhs) {
-        return MATHS.unsignedLongMulXorFold(lhs, rhs);
+        return Maths.unsignedLongMulXorFold(lhs, rhs);
     }
 
     private static <T> long _wyr3(final Access<T> access, T in, final long index, long k) {

--- a/src/main/java/net/openhft/hashing/XxHash.java
+++ b/src/main/java/net/openhft/hashing/XxHash.java
@@ -31,22 +31,6 @@ class XxHash {
     private static final long P4 = -8796714831421723037L;
     private static final long P5 = 2870177450012600261L;
 
-    private XxHash() {}
-
-    static <T> long fetch64(Access<T> access, T in, long off) {
-        return access.getLong(in, off);
-    }
-
-    // long because of unsigned nature of original algorithm
-    static <T> long fetch32(Access<T> access, T in, long off) {
-        return access.getUnsignedInt(in, off);
-    }
-
-    // int because of unsigned nature of original algorithm
-    static private <T> int fetch8(Access<T> access, T in, long off) {
-        return access.getUnsignedByte(in, off);
-    }
-
     static <T> long xxHash64(long seed, T input, Access<T> access, long off, long length) {
         long hash;
         long remaining = length;
@@ -58,19 +42,19 @@ class XxHash {
             long v4 = seed - P1;
 
             do {
-                v1 += fetch64(access, input, off) * P2;
+                v1 += access.i64(input, off) * P2;
                 v1 = Long.rotateLeft(v1, 31);
                 v1 *= P1;
 
-                v2 += fetch64(access, input, off + 8) * P2;
+                v2 += access.i64(input, off + 8) * P2;
                 v2 = Long.rotateLeft(v2, 31);
                 v2 *= P1;
 
-                v3 += fetch64(access, input, off + 16) * P2;
+                v3 += access.i64(input, off + 16) * P2;
                 v3 = Long.rotateLeft(v3, 31);
                 v3 *= P1;
 
-                v4 += fetch64(access, input, off + 24) * P2;
+                v4 += access.i64(input, off + 24) * P2;
                 v4 = Long.rotateLeft(v4, 31);
                 v4 *= P1;
 
@@ -113,7 +97,7 @@ class XxHash {
         hash += length;
 
         while (remaining >= 8) {
-            long k1 = fetch64(access, input, off);
+            long k1 = access.i64(input, off);
             k1 *= P2;
             k1 = Long.rotateLeft(k1, 31);
             k1 *= P1;
@@ -124,14 +108,14 @@ class XxHash {
         }
 
         if (remaining >= 4) {
-            hash ^= fetch32(access, input, off) * P1;
+            hash ^= access.u32(input, off) * P1;
             hash = Long.rotateLeft(hash, 23) * P2 + P3;
             off += 4;
             remaining -= 4;
         }
 
         while (remaining != 0) {
-            hash ^= fetch8(access, input, off) * P5;
+            hash ^= access.u8(input, off) * P5;
             hash = Long.rotateLeft(hash, 11) * P1;
             --remaining;
             ++off;

--- a/src/main/java/net/openhft/hashing/XxHash.java
+++ b/src/main/java/net/openhft/hashing/XxHash.java
@@ -51,18 +51,6 @@ class XxHash {
         return access.getUnsignedByte(in, off);
     }
 
-    long toLittleEndian(long v) {
-        return v;
-    }
-
-    int toLittleEndian(int v) {
-        return v;
-    }
-
-    short toLittleEndian(short v) {
-        return v;
-    }
-
     <T> long xxHash64(long seed, T input, Access<T> access, long off, long length) {
         long hash;
         long remaining = length;
@@ -181,21 +169,6 @@ class XxHash {
         }
 
         // fetch8 is not overloaded, because endianness doesn't matter for single byte
-
-        @Override
-        long toLittleEndian(long v) {
-            return Long.reverseBytes(v);
-        }
-
-        @Override
-        int toLittleEndian(int v) {
-            return Integer.reverseBytes(v);
-        }
-
-        @Override
-        short toLittleEndian(short v) {
-            return Short.reverseBytes(v);
-        }
     }
 
     static LongHashFunction asLongHashFunctionWithoutSeed() {
@@ -217,7 +190,7 @@ class XxHash {
 
         @Override
         public long hashLong(long input) {
-            input = NATIVE_XX.toLittleEndian(input);
+            input = Primitives.nativeToLittleEndian(input);
             long hash = seed() + P5 + 8;
             input *= P2;
             input = Long.rotateLeft(input, 31);
@@ -229,7 +202,7 @@ class XxHash {
 
         @Override
         public long hashInt(int input) {
-            input = NATIVE_XX.toLittleEndian(input);
+            input = Primitives.nativeToLittleEndian(input);
             long hash = seed() + P5 + 4;
             hash ^= Primitives.unsignedInt(input) * P1;
             hash = Long.rotateLeft(hash, 23) * P2 + P3;
@@ -238,7 +211,7 @@ class XxHash {
 
         @Override
         public long hashShort(short input) {
-            input = NATIVE_XX.toLittleEndian(input);
+            input = Primitives.nativeToLittleEndian(input);
             long hash = seed() + P5 + 2;
             hash ^= Primitives.unsignedByte(input) * P5;
             hash = Long.rotateLeft(hash, 11) * P1;

--- a/src/test/java/net/openhft/hashing/CharSequenceAccessTest.java
+++ b/src/test/java/net/openhft/hashing/CharSequenceAccessTest.java
@@ -33,28 +33,58 @@ public class CharSequenceAccessTest {
     }
 
     @Test
+    public void testInstanceReverse() {
+        Access<CharSequence> access = CharSequenceAccess.charSequenceAccess(BIG_ENDIAN);
+        assertSame(access, access.reverseAccess().reverseAccess());
+        assertNotSame(access.byteOrder(null), access.reverseAccess().byteOrder(null));
+        assertSame(access.byteOrder(null, BIG_ENDIAN), access);
+        assertNotSame(access.byteOrder(null, LITTLE_ENDIAN), access);
+
+        access = CharSequenceAccess.charSequenceAccess(LITTLE_ENDIAN);
+        assertSame(access, access.reverseAccess().reverseAccess());
+        assertNotSame(access.byteOrder(null), access.reverseAccess().byteOrder(null));
+        assertSame(access.byteOrder(null, LITTLE_ENDIAN), access);
+        assertNotSame(access.byteOrder(null, BIG_ENDIAN), access);
+    }
+
+    @Test
     public void testLittleEndian() {
         // This case works on both little- and big- endians.
 
         final Access<CharSequence> access = CharSequenceAccess.charSequenceAccess(LITTLE_ENDIAN);
+        final Access<CharSequence> accessR = access.reverseAccess();
 
         assertEquals(  0x9687B4A5D2C3F0E1L, access.getLong(TEST_STRING, 0));
         assertEquals(0xE99687B4A5D2C3F0L  , access.getLong(TEST_STRING, 1));
+        assertEquals(0xE1F0C3D2A5B48796L  , accessR.getLong(TEST_STRING, 0));
+        assertEquals(  0xF0C3D2A5B48796E9L, accessR.getLong(TEST_STRING, 1));
 
         assertEquals(unsignedInt(  0xD2C3F0E1), access.getUnsignedInt(TEST_STRING, 0));
         assertEquals(unsignedInt(0xA5D2C3F0  ), access.getUnsignedInt(TEST_STRING, 1));
         assertEquals(  0xD2C3F0E1, access.getInt(TEST_STRING, 0));
         assertEquals(0xA5D2C3F0  , access.getInt(TEST_STRING, 1));
+        assertEquals(unsignedInt(0xE1F0C3D2)  , accessR.getUnsignedInt(TEST_STRING, 0));
+        assertEquals(unsignedInt(  0xF0C3D2A5), accessR.getUnsignedInt(TEST_STRING, 1));
+        assertEquals(0xE1F0C3D2  , accessR.getInt(TEST_STRING, 0));
+        assertEquals(  0xF0C3D2A5, accessR.getInt(TEST_STRING, 1));
 
         assertEquals(unsignedShort(  0xF0E1), access.getUnsignedShort(TEST_STRING, 0));
         assertEquals(unsignedShort(0xC3F0  ), access.getUnsignedShort(TEST_STRING, 1));
         assertEquals((int)(short)  0xF0E1, access.getShort(TEST_STRING, 0));
         assertEquals((int)(short)0xC3F0  , access.getShort(TEST_STRING, 1));
+        assertEquals(unsignedShort(0xE1F0  ), accessR.getUnsignedShort(TEST_STRING, 0));
+        assertEquals(unsignedShort(  0xF0C3), accessR.getUnsignedShort(TEST_STRING, 1));
+        assertEquals((int)(short)0xE1F0  , accessR.getShort(TEST_STRING, 0));
+        assertEquals((int)(short)  0xF0C3, accessR.getShort(TEST_STRING, 1));
 
         assertEquals(unsignedByte(0xE1), access.getUnsignedByte(TEST_STRING, 0));
         assertEquals(unsignedByte(0xF0), access.getUnsignedByte(TEST_STRING, 1));
         assertEquals((int)(byte)0xE1, access.getByte(TEST_STRING, 0));
         assertEquals((int)(byte)0xF0, access.getByte(TEST_STRING, 1));
+        assertEquals(unsignedByte(0xE1), accessR.getUnsignedByte(TEST_STRING, 0));
+        assertEquals(unsignedByte(0xF0), accessR.getUnsignedByte(TEST_STRING, 1));
+        assertEquals((int)(byte)0xE1, accessR.getByte(TEST_STRING, 0));
+        assertEquals((int)(byte)0xF0, accessR.getByte(TEST_STRING, 1));
     }
 
     @Test

--- a/src/test/java/net/openhft/hashing/MathsTest.java
+++ b/src/test/java/net/openhft/hashing/MathsTest.java
@@ -5,24 +5,22 @@ import org.junit.Test;
 import static org.junit.Assert.assertEquals;
 
 public class MathsTest {
-    private static Maths m = Maths.INSTANCE;
-
     @Test
     public void testUnsignedLongMulXorFold() {
         {
             long x = 0x100000001L;
             long y = 0x200000002L;
-            assertEquals(2L ^ 0x400000002L, m.unsignedLongMulXorFold(x, y));
+            assertEquals(2L ^ 0x400000002L, Maths.unsignedLongMulXorFold(x, y));
         }
         {
             long x = -1;
             long y = -1;
-            assertEquals((-2) ^ 1, m.unsignedLongMulXorFold(x, y));
+            assertEquals((-2) ^ 1, Maths.unsignedLongMulXorFold(x, y));
         }
         {
             long x = -1;
             long y = 0x300000003L;
-            assertEquals(0x300000002L ^ (-0x300000003L), m.unsignedLongMulXorFold(x, y));
+            assertEquals(0x300000002L ^ (-0x300000003L), Maths.unsignedLongMulXorFold(x, y));
         }
     }
 }

--- a/src/test/java/net/openhft/hashing/PrimitivesTest.java
+++ b/src/test/java/net/openhft/hashing/PrimitivesTest.java
@@ -1,0 +1,52 @@
+package net.openhft.hashing;
+
+import org.junit.Test;
+
+import static java.nio.ByteOrder.BIG_ENDIAN;
+import static java.nio.ByteOrder.LITTLE_ENDIAN;
+import static java.nio.ByteOrder.nativeOrder;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assume.assumeTrue;
+
+public class PrimitivesTest {
+
+    static final long l = 0x0123456789ABCDEFL;
+    static final int i = 0x01234567;
+    static final short s = 0x0123;
+    static final short c = 0x4567;
+
+    static final long rl = 0xEFCDAB8967452301L;
+    static final int ri = 0x67452301;
+    static final short rs = 0x2301;
+    static final short rc = 0x6745;
+
+    @Test
+    public void testLE() {
+        assumeTrue(nativeOrder() == LITTLE_ENDIAN);
+
+        assertEquals(l, Primitives.nativeToLittleEndian(l));
+        assertEquals(i, Primitives.nativeToLittleEndian(i));
+        assertEquals(s, Primitives.nativeToLittleEndian(s));
+        assertEquals(c, Primitives.nativeToLittleEndian(c));
+
+        assertEquals(rl, Primitives.nativeToBigEndian(l));
+        assertEquals(ri, Primitives.nativeToBigEndian(i));
+        assertEquals(rs, Primitives.nativeToBigEndian(s));
+        assertEquals(rc, Primitives.nativeToBigEndian(c));
+    }
+
+    @Test
+    public void testBE() {
+        assumeTrue(nativeOrder() == BIG_ENDIAN);
+
+        assertEquals(rl, Primitives.nativeToLittleEndian(l));
+        assertEquals(ri, Primitives.nativeToLittleEndian(i));
+        assertEquals(rs, Primitives.nativeToLittleEndian(s));
+        assertEquals(rc, Primitives.nativeToLittleEndian(c));
+
+        assertEquals(l, Primitives.nativeToBigEndian(l));
+        assertEquals(i, Primitives.nativeToBigEndian(i));
+        assertEquals(s, Primitives.nativeToBigEndian(s));
+        assertEquals(c, Primitives.nativeToBigEndian(c));
+    }
+}


### PR DESCRIPTION
1. move the byte order converting logic into `Primitives` and `Access` class
2. replace common `fetch*` methods in hash class by the `Access` short api

After refactoring, the hashing functions could only care about the calculations in `static` methods and create suitable `LongHashFunction/LongTupleHashFunction` instances.