### PR TITLE
Fix static initialization deadlock (Fixes #53)

### DIFF
--- a/src/main/java/net/openhft/hashing/CityAndFarmHash_1_1.java
+++ b/src/main/java/net/openhft/hashing/CityAndFarmHash_1_1.java
@@ -19,7 +19,7 @@ package net.openhft.hashing;
 import static java.lang.Long.reverseBytes;
 import static java.lang.Long.rotateRight;
 import static java.nio.ByteOrder.LITTLE_ENDIAN;
-import static net.openhft.hashing.Util.NATIVE_LITTLE_ENDIAN;
+import static net.openhft.hashing.Primitives.NATIVE_LITTLE_ENDIAN;
 
 /**
  * Adapted from the C++ CityHash implementation from Google at

--- a/src/main/java/net/openhft/hashing/MetroHash.java
+++ b/src/main/java/net/openhft/hashing/MetroHash.java
@@ -1,7 +1,6 @@
 package net.openhft.hashing;
 
 import static java.nio.ByteOrder.LITTLE_ENDIAN;
-import static net.openhft.hashing.Util.NATIVE_LITTLE_ENDIAN;
 
 class MetroHash {
     //primes

--- a/src/main/java/net/openhft/hashing/MurmurHash_3.java
+++ b/src/main/java/net/openhft/hashing/MurmurHash_3.java
@@ -20,9 +20,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
-import static java.lang.Long.reverseBytes;
 import static java.nio.ByteOrder.LITTLE_ENDIAN;
-import static net.openhft.hashing.Util.NATIVE_LITTLE_ENDIAN;
 import static net.openhft.hashing.Primitives.unsignedInt;
 import static net.openhft.hashing.Primitives.unsignedShort;
 

--- a/src/main/java/net/openhft/hashing/Primitives.java
+++ b/src/main/java/net/openhft/hashing/Primitives.java
@@ -16,11 +16,14 @@
 
 package net.openhft.hashing;
 
-import static net.openhft.hashing.Util.NATIVE_LITTLE_ENDIAN;
+import static java.nio.ByteOrder.LITTLE_ENDIAN;
+import static java.nio.ByteOrder.nativeOrder;
 
 final class Primitives {
 
     private Primitives() {}
+
+    static final boolean NATIVE_LITTLE_ENDIAN = nativeOrder() == LITTLE_ENDIAN;
 
     static long unsignedInt(int i) {
         return i & 0xFFFFFFFFL;

--- a/src/main/java/net/openhft/hashing/UnsafeAccess.java
+++ b/src/main/java/net/openhft/hashing/UnsafeAccess.java
@@ -21,7 +21,6 @@ import java.nio.ByteOrder;
 import sun.misc.Unsafe;
 
 import static net.openhft.hashing.Primitives.*;
-import static net.openhft.hashing.Util.NATIVE_LITTLE_ENDIAN;
 
 public class UnsafeAccess extends Access<Object> {
     static final UnsafeAccess INSTANCE;

--- a/src/main/java/net/openhft/hashing/Util.java
+++ b/src/main/java/net/openhft/hashing/Util.java
@@ -8,7 +8,6 @@ import org.jetbrains.annotations.NotNull;
 import static java.nio.ByteOrder.*;
 
 final class Util {
-    static final boolean NATIVE_LITTLE_ENDIAN = nativeOrder() == LITTLE_ENDIAN;
 
     /* Known java.vm.name list:
      *

--- a/src/main/java/net/openhft/hashing/WyHash.java
+++ b/src/main/java/net/openhft/hashing/WyHash.java
@@ -1,7 +1,6 @@
 package net.openhft.hashing;
 
 import static java.nio.ByteOrder.LITTLE_ENDIAN;
-import static net.openhft.hashing.Util.NATIVE_LITTLE_ENDIAN;
 
 /**
  * Adapted version of WyHash implementation from https://github.com/wangyi-fudan/wyhash

--- a/src/main/java/net/openhft/hashing/XXH3.java
+++ b/src/main/java/net/openhft/hashing/XXH3.java
@@ -21,7 +21,6 @@ import java.nio.ByteBuffer;
 import static java.nio.ByteOrder.LITTLE_ENDIAN;
 import static net.openhft.hashing.Maths.unsignedLongMulXorFold;
 import static net.openhft.hashing.UnsafeAccess.*;
-import static net.openhft.hashing.Util.NATIVE_LITTLE_ENDIAN;
 
 /**
  * Adapted version of XXH3 implementation from https://github.com/Cyan4973/xxHash.

--- a/src/main/java/net/openhft/hashing/XxHash.java
+++ b/src/main/java/net/openhft/hashing/XxHash.java
@@ -17,7 +17,6 @@
 package net.openhft.hashing;
 
 import static java.nio.ByteOrder.LITTLE_ENDIAN;
-import static net.openhft.hashing.Util.NATIVE_LITTLE_ENDIAN;
 
 /**
  * Adapted version of xxHash implementation from https://github.com/Cyan4973/xxHash.


### PR DESCRIPTION
There is a dependency cycle in the static initializers of Utils and UnsafeAccess which can cause a deadlock if both classes are static-initialized in different threads.

Specifically, the cycle is the one shown by these stack traces:

Thread 1
```
   java.lang.Thread.State: RUNNABLE
    at net.openhft.hashing.CompactLatin1CharSequenceAccess.<clinit>(CompactLatin1CharSequenceAccess.java:83)
    - waiting on the Class initialization monitor for net.openhft.hashing.UnsafeAccess
    at net.openhft.hashing.ModernCompactStringHash.<clinit>(ModernCompactStringHash.java:14)
    at net.openhft.hashing.Util.<clinit>(Util.java:41)
```

Thread 2
```
   java.lang.Thread.State: RUNNABLE
    at net.openhft.hashing.UnsafeAccess.<clinit>(UnsafeAccess.java:30)
    - waiting on the Class initialization monitor for net.openhft.hashing.Util
```

This is due to the `NATIVE_LITTLE_ENDIAN` field. This PR moves this field to the `Primitives` class, which does not depend on any other class in the project, to avoid this deadlock.