### PR TITLE
Restore `LongHashFunction.xx_r39()` to allow consumers to migrate to `xx()`

### DIFF
--- a/src/main/java/net/openhft/hashing/LongHashFunction.java
+++ b/src/main/java/net/openhft/hashing/LongHashFunction.java
@@ -285,6 +285,32 @@ public abstract class LongHashFunction implements Serializable {
     }
 
     /**
+     * Returns a hash function implementing the <a href="https://github.com/Cyan4973/xxHash">xxHash
+     * algorithm</a> without a seed value (0 is used as default seed value). This implementation
+     * produces equal results for equal input on platforms with different {@link
+     * ByteOrder}, but is slower on big-endian platforms than on little-endian.
+     *
+     * @deprecated use {link #xx()} instead; this method exists for backwards compatibility.
+     */
+    @Deprecated
+    public static LongHashFunction xx_r39() {
+        return xx();
+    }
+
+    /**
+     * Returns a hash function implementing the <a href="https://github.com/Cyan4973/xxHash">xxHash
+     * algorithm</a> with the given seed value. This implementation produces equal results for equal
+     * input on platforms with different {@link ByteOrder}, but is slower on big-endian platforms
+     * than on little-endian.
+     *
+     * @deprecated use {link #xx(long)} instead; this method exists for backwards compatibility.
+     */
+    @Deprecated
+    public static LongHashFunction xx_r39(long seed) {
+        return xx(seed);
+    }
+
+    /**
      * Returns a hash function implementing the <a href="https://github.com/Cyan4973/xxHash">XXH3 64bit
      * algorithm</a> without a seed value (0 is used as default seed value). This implementation
      * produces equal results for equal input on platforms with different {@link


### PR DESCRIPTION
Add alias to LongHashFunction.xx() called LongHashFunction.xx_r39() to allow consumers to migrate code from xx_r39() to xx() without breaking at runtime.

The LongHashFunction.xx_r39() method delegates to LongHashFunction.xx() so it is identical in behavior. It's marked as deprecated.

## Context

Some large companies make use of `Zero-Allocation-Hashing` because it is so useful. In https://github.com/OpenHFT/Zero-Allocation-Hashing/commit/658079a50903c32c54f2ab5c86243244b3ac60ed the `LongHashFunction.xx_r39()` method was renamed to the more general `LongHashFunction.xx()`. Since this method is public, this was a breaking change. Since the cutover from `LongHashFunction.xx_r39()` to `LongHashFunction.xx()` was immediate, any consumer has to ensure that their code no longer uses `LongHashFunction.xx_r39()` as well as any of their (potentially compiled) dependencies. If a dependency was compiled against an older version of `Zero-Allocation-Hashing` where `LongHashFunction.xx_r39()` still exists, then it will blow up at runtime since the method can no longer be found on the class.

At LinkedIn, we use `Zero-Allocation-Hashing` both in our internal and open-source libraries. We want to update to the latest version, but cannot easily do it without a way to cut over from `LongHashFunction.xx_r39()` to `LongHashFunction.xx()`.

Please consider merging this patch for compatibility's sake. It will help software developers keep their dependencies up to date!