### PR TITLE
Make import to internal sun classes and the annotations optional

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -279,8 +279,15 @@
                             !java.*,
                             !sun.*
                         </Export-Package>
-                        <Private-Package>!java.*,!sun.*</Private-Package>
-                        <Import-Package>*</Import-Package>
+                        <Private-Package>
+                            !java.*,
+                            !sun.*
+                        </Private-Package>
+                        <Import-Package>
+                            javax.annotation;resolution:=optional;bundle-symbolic-name="${@bundlesymbolicname}",
+                            sun.*;resolution:=optional,
+                            *
+                        </Import-Package>
                     </instructions>
                 </configuration>
                 <executions>


### PR DESCRIPTION
the sun.* classes are internal depending on the jvm settings especially the 'sun.nio.ch', this currently makes the lib unusable in its provided form without special configuration.

As the sun.nio.ch is actually optional (it is only used after instanceof checks) it could be marked optional import in the manifest so it is sued whenever the jvm provides the package and otherwise will not be used at all.

Also the annotations import is actually optional as the code does not reference it anywhere except as an annotation on methods/classes so the absence will just make the annotations invisible on runtime if not provided.

Beside that, it is actually a split package and therefore needs to mention the bundle it wants to import the package from.

This changes all sun.* packages to optional as well as the javax.annotation package and additionally mentions the bundle it wants to import the annotations from.

The (shortened) resulting manifest looks like this:
```
Manifest-Version: 1.0
Bundle-ManifestVersion: 2
Bundle-Name: OpenHFT :: zero-allocation-hashing
Bundle-SymbolicName: net.openhft.zero-allocation-hashing
Bundle-Version: 0.17.0.SNAPSHOT
Export-Package: net.openhft.hashing;uses:="javax.annotation";version="0.17.0.SNAPSHOT"
Import-Package: javax.annotation;resolution:=optional;bundle-symbolic-name="org.jsr-305";version="[3.0,4)",
 sun.misc;resolution:=optional,
 sun.nio.ch;resolution:=optional
Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.7))"
```