### PR TITLE
Fix maven-release-plugin version incompatibility with maven-scm

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -218,6 +218,7 @@
     
             <plugin>
                 <artifactId>maven-release-plugin</artifactId>
+                <version>3.0.0-M4</version>
                 <dependencies>
                     <dependency>
                         <groupId>org.apache.maven.scm</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -325,7 +325,7 @@
                                     <goal>test</goal>
                                 </goals>
                                 <configuration>
-                                    <argLine>-XX:-CompactStrings</argLine>
+                                    <argLine>@{argLine} -XX:-CompactStrings ${jvm.requiredArgs}</argLine>
                                 </configuration>
                             </execution>
                         </executions>


### PR DESCRIPTION
                                                                                                                                                                                                                                                            
# Summary                                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                               
  - Restores explicit maven-release-plugin version 3.0.0-M4 to fix NoSuchMethodError during mvn release:prepare                                                                                                                                                
                                                                                                                                                                                                                                                               
# Problem                                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                               
  Commit 892a7bf removed the explicit plugin version but kept the maven-scm-provider-gitexe:1.11.2 dependency. The parent POM's maven-release-plugin:3.0.1 requires maven-scm 2.x APIs, causing:                                                               
  java.lang.NoSuchMethodError: org.apache.maven.scm.provider.git.AbstractGitScmProvider.getLogger()                                                                                                                                                            
                                                                                                                                                                                                                                                               
# Test                                                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                               
  mvn release:prepare -DdryRun=true -Darguments="-DskipTests"  