### PR TITLE
Upgrade workflow caches and print Maven and JDK versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,13 +19,13 @@ jobs:
         with:
           java-version: 11
       - name: Cache SonarCloud packages
-        uses: actions/cache@v1
+        uses: actions/cache@v5
         with:
           path: ~/.sonar/cache
           key: ${{ runner.os }}-sonar
           restore-keys: ${{ runner.os }}-sonar
       - name: Cache Maven packages
-        uses: actions/cache@v1
+        uses: actions/cache@v5
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,4 +34,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: mvn -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=OpenHFT_Zero-Allocation-Hashing -Psonar
+        run: |
+          mvn \
+            --show-version \
+            --batch-mode \
+            verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar \
+            -Dsonar.projectKey=OpenHFT_Zero-Allocation-Hashing \
+            -Psonar


### PR DESCRIPTION
Update the Sonar and Maven cache steps in the build workflow from `actions/cache@v1` to `actions/cache@v5`. Reformat the existing Maven verification/Sonar command and add batch mode and version output to make its execution easier to diagnose.

Run the workflow on its configured runner and check cache restore/save and Maven execution. The discussion records a dependent contributor follow-up; preserve that ordering when integrating the source change.

Validation: the diff and recorded review/check history were inspected at `f2cc346e47de`. No build, test or benchmark was rerun for this metadata edit. No CI result was returned for this head.
