### PR TITLE
docs: bump copyright year end to 2026

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+    Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
 
 -->
 

--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,7 @@
     <packaging>bundle</packaging>
 
     <properties>
+        <license.year>2013-2026</license.year>
         <!-- specify the target Java SE release, at least 7 -->
         <project.target.release>8</project.target.release>
 

--- a/src/main/java-stub/java/lang/Math.java
+++ b/src/main/java-stub/java/lang/Math.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package java.lang;
 

--- a/src/main/java-stub/sun/misc/Unsafe.java
+++ b/src/main/java-stub/sun/misc/Unsafe.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package sun.misc;
 

--- a/src/main/java/net/openhft/hashing/Access.java
+++ b/src/main/java/net/openhft/hashing/Access.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.hashing;
 

--- a/src/main/java/net/openhft/hashing/ByteBufferAccess.java
+++ b/src/main/java/net/openhft/hashing/ByteBufferAccess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.hashing;
 

--- a/src/main/java/net/openhft/hashing/CharSequenceAccess.java
+++ b/src/main/java/net/openhft/hashing/CharSequenceAccess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.hashing;
 

--- a/src/main/java/net/openhft/hashing/CityAndFarmHash_1_1.java
+++ b/src/main/java/net/openhft/hashing/CityAndFarmHash_1_1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.hashing;
 

--- a/src/main/java/net/openhft/hashing/CompactLatin1CharSequenceAccess.java
+++ b/src/main/java/net/openhft/hashing/CompactLatin1CharSequenceAccess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.hashing;
 

--- a/src/main/java/net/openhft/hashing/DualHashFunction.java
+++ b/src/main/java/net/openhft/hashing/DualHashFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.hashing;
 

--- a/src/main/java/net/openhft/hashing/HotSpotPrior7u6StringHash.java
+++ b/src/main/java/net/openhft/hashing/HotSpotPrior7u6StringHash.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.hashing;
 

--- a/src/main/java/net/openhft/hashing/LongHashFunction.java
+++ b/src/main/java/net/openhft/hashing/LongHashFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.hashing;
 

--- a/src/main/java/net/openhft/hashing/LongTupleHashFunction.java
+++ b/src/main/java/net/openhft/hashing/LongTupleHashFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.hashing;
 

--- a/src/main/java/net/openhft/hashing/Maths.java
+++ b/src/main/java/net/openhft/hashing/Maths.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.hashing;
 

--- a/src/main/java/net/openhft/hashing/MetroHash.java
+++ b/src/main/java/net/openhft/hashing/MetroHash.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.hashing;
 

--- a/src/main/java/net/openhft/hashing/ModernCompactStringHash.java
+++ b/src/main/java/net/openhft/hashing/ModernCompactStringHash.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.hashing;
 

--- a/src/main/java/net/openhft/hashing/ModernHotSpotStringHash.java
+++ b/src/main/java/net/openhft/hashing/ModernHotSpotStringHash.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.hashing;
 

--- a/src/main/java/net/openhft/hashing/MurmurHash_3.java
+++ b/src/main/java/net/openhft/hashing/MurmurHash_3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.hashing;
 

--- a/src/main/java/net/openhft/hashing/Primitives.java
+++ b/src/main/java/net/openhft/hashing/Primitives.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.hashing;
 

--- a/src/main/java/net/openhft/hashing/StringHash.java
+++ b/src/main/java/net/openhft/hashing/StringHash.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.hashing;
 

--- a/src/main/java/net/openhft/hashing/UnknownJvmStringHash.java
+++ b/src/main/java/net/openhft/hashing/UnknownJvmStringHash.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.hashing;
 

--- a/src/main/java/net/openhft/hashing/UnsafeAccess.java
+++ b/src/main/java/net/openhft/hashing/UnsafeAccess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.hashing;
 

--- a/src/main/java/net/openhft/hashing/Util.java
+++ b/src/main/java/net/openhft/hashing/Util.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.hashing;
 

--- a/src/main/java/net/openhft/hashing/WyHash.java
+++ b/src/main/java/net/openhft/hashing/WyHash.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.hashing;
 

--- a/src/main/java/net/openhft/hashing/XXH3.java
+++ b/src/main/java/net/openhft/hashing/XXH3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.hashing;
 

--- a/src/main/java/net/openhft/hashing/XxHash.java
+++ b/src/main/java/net/openhft/hashing/XxHash.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.hashing;
 

--- a/src/main/java/net/openhft/hashing/package-info.java
+++ b/src/main/java/net/openhft/hashing/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 /**
  * API for hashing sequential data and zero-allocation, pretty fast implementations

--- a/src/main/java/sun/nio/ch/DirectBuffer.java
+++ b/src/main/java/sun/nio/ch/DirectBuffer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package sun.nio.ch;
 

--- a/src/test/java/net/openhft/hashing/ByteBufferAccessTest.java
+++ b/src/test/java/net/openhft/hashing/ByteBufferAccessTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.hashing;
 

--- a/src/test/java/net/openhft/hashing/CharSequenceAccessTest.java
+++ b/src/test/java/net/openhft/hashing/CharSequenceAccessTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.hashing;
 

--- a/src/test/java/net/openhft/hashing/City64_1_1_Test.java
+++ b/src/test/java/net/openhft/hashing/City64_1_1_Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.hashing;
 

--- a/src/test/java/net/openhft/hashing/CompactLatin1CharSequenceAccessTest.java
+++ b/src/test/java/net/openhft/hashing/CompactLatin1CharSequenceAccessTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.hashing;
 

--- a/src/test/java/net/openhft/hashing/DualHashFunctionTest.java
+++ b/src/test/java/net/openhft/hashing/DualHashFunctionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.hashing;
 

--- a/src/test/java/net/openhft/hashing/FarmHashTest.java
+++ b/src/test/java/net/openhft/hashing/FarmHashTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.hashing;
 

--- a/src/test/java/net/openhft/hashing/LongHashFunctionTest.java
+++ b/src/test/java/net/openhft/hashing/LongHashFunctionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.hashing;
 

--- a/src/test/java/net/openhft/hashing/LongTupleHashFunctionTest.java
+++ b/src/test/java/net/openhft/hashing/LongTupleHashFunctionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.hashing;
 

--- a/src/test/java/net/openhft/hashing/MathsTest.java
+++ b/src/test/java/net/openhft/hashing/MathsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.hashing;
 

--- a/src/test/java/net/openhft/hashing/MetroHashTest.java
+++ b/src/test/java/net/openhft/hashing/MetroHashTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.hashing;
 

--- a/src/test/java/net/openhft/hashing/ModernCompactStringHashTest.java
+++ b/src/test/java/net/openhft/hashing/ModernCompactStringHashTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.hashing;
 

--- a/src/test/java/net/openhft/hashing/MurmurHash3Test.java
+++ b/src/test/java/net/openhft/hashing/MurmurHash3Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.hashing;
 

--- a/src/test/java/net/openhft/hashing/OriginalFarmHashTest.java
+++ b/src/test/java/net/openhft/hashing/OriginalFarmHashTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.hashing;
 

--- a/src/test/java/net/openhft/hashing/PrimitivesTest.java
+++ b/src/test/java/net/openhft/hashing/PrimitivesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.hashing;
 

--- a/src/test/java/net/openhft/hashing/UnsafeAccessTest.java
+++ b/src/test/java/net/openhft/hashing/UnsafeAccessTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.hashing;
 

--- a/src/test/java/net/openhft/hashing/UtilTest.java
+++ b/src/test/java/net/openhft/hashing/UtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.hashing;
 

--- a/src/test/java/net/openhft/hashing/WyHashTest.java
+++ b/src/test/java/net/openhft/hashing/WyHashTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.hashing;
 

--- a/src/test/java/net/openhft/hashing/XXH128Test.java
+++ b/src/test/java/net/openhft/hashing/XXH128Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.hashing;
 

--- a/src/test/java/net/openhft/hashing/XXH3Test.java
+++ b/src/test/java/net/openhft/hashing/XXH3Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.hashing;
 

--- a/src/test/java/net/openhft/hashing/XxHashCollisionTest.java
+++ b/src/test/java/net/openhft/hashing/XxHashCollisionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.hashing;
 

--- a/src/test/java/net/openhft/hashing/XxHashTest.java
+++ b/src/test/java/net/openhft/hashing/XxHashTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.hashing;
 


### PR DESCRIPTION
## Summary
- Rolls `Copyright YYYY-20XX chronicle.software` / `higherfrequencytrading.com` forward so the end year matches the current calendar year (2026).
- Non-chronicle copyrights (third-party headers, etc.) are intentionally left alone.
- Adds a local `license.year=2013-2026` override in the project POM so `license-maven-plugin` validates the updated headers correctly on CI.
- Behaviour-neutral; no logic changes.

## Test plan
- [ ] Visual diff review - expect header year updates plus the `license.year` POM override.
- [ ] `mvn -DskipTests license:check`
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)