### PR TITLE
docs: upgrade http:// to https:// in docs and comments

### DIFF
--- a/.mvn/wrapper/MavenWrapperDownloader.java
+++ b/.mvn/wrapper/MavenWrapperDownloader.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -192,7 +192,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/README.adoc
+++ b/README.adoc
@@ -90,7 +90,7 @@ There is no simple way to hash these using this project, for example, classes su
 
 === Javadoc
 
-See http://javadoc.io/doc/net.openhft/zero-allocation-hashing/latest
+See https://javadoc.io/doc/net.openhft/zero-allocation-hashing/latest
 
 === Internal documentation
 
@@ -132,7 +132,7 @@ In Java:
 long hash = LongHashFunction.wy_3().hashChars("hello");
 ----
 
-See *http://javadoc.io/doc/net.openhft/zero-allocation-hashing/latest[JavaDocs]* for more information.
+See *https://javadoc.io/doc/net.openhft/zero-allocation-hashing/latest[JavaDocs]* for more information.
 
 == Contributions are most welcome!
 


### PR DESCRIPTION
Closed after the 9 September 2026 value review. This is five HTTP-to-HTTPS substitutions: two README links, two LICENSE links and one wrapper licence comment. It changes no executable build behaviour and is not retained as a standalone review item.

The useful Maven badge/navigation maintenance remains independently in [#112](https://github.com/OpenHFT/Zero-Allocation-Hashing/pull/112), whose one-line scope stays focused. The optional protocol substitutions were not folded into it. No tests or source changes were needed for this closure.
