### PR TITLE
docs: close the space in "i. e." and "e. g."

### DIFF
--- a/src/main/java/net/openhft/hashing/LongHashFunction.java
+++ b/src/main/java/net/openhft/hashing/LongHashFunction.java
@@ -626,7 +626,7 @@ public abstract class LongHashFunction implements Serializable {
      *
      * @param input the array to read data from
      * @param off   index of the first {@code char} in the subsequence to hash
-     * @param len   length of the subsequence to hash, in chars (i. e. the length of the bytes
+     * @param len   length of the subsequence to hash, in chars (i.e. the length of the bytes
      *              sequence to hash is {@code len * 2L})
      * @return hash code for the specified subsequence
      * @throws IndexOutOfBoundsException if {@code off < 0} or {@code off + len > input.length}
@@ -656,7 +656,7 @@ public abstract class LongHashFunction implements Serializable {
      *
      * @param input the string which bytes to hash
      * @param off   index of the first {@code char} in the subsequence to hash
-     * @param len   length of the subsequence to hash, in chars (i. e. the length of the bytes
+     * @param len   length of the subsequence to hash, in chars (i.e. the length of the bytes
      *              sequence to hash is {@code len * 2L})
      * @return the hash code of the given {@code String}'s bytes
      * @throws IndexOutOfBoundsException if {@code off < 0} or {@code off + len > input.length()}
@@ -686,7 +686,7 @@ public abstract class LongHashFunction implements Serializable {
      *
      * @param input the string builder which bytes to hash
      * @param off   index of the first {@code char} in the subsequence to hash
-     * @param len   length of the subsequence to hash, in chars (i. e. the length of the bytes
+     * @param len   length of the subsequence to hash, in chars (i.e. the length of the bytes
      *              sequence to hash is {@code len * 2L})
      * @return the hash code of the given {@code String}'s bytes
      * @throws IndexOutOfBoundsException if {@code off < 0} or {@code off + len > input.length()}
@@ -738,7 +738,7 @@ public abstract class LongHashFunction implements Serializable {
      *
      * @param input the array to read data from
      * @param off   index of the first {@code short} in the subsequence to hash
-     * @param len   length of the subsequence to hash, in shorts (i. e. the length of the bytes
+     * @param len   length of the subsequence to hash, in shorts (i.e. the length of the bytes
      *              sequence to hash is {@code len * 2L})
      * @return hash code for the specified subsequence
      * @throws IndexOutOfBoundsException if {@code off < 0} or {@code off + len > input.length}
@@ -768,7 +768,7 @@ public abstract class LongHashFunction implements Serializable {
      *
      * @param input the array to read data from
      * @param off   index of the first {@code int} in the subsequence to hash
-     * @param len   length of the subsequence to hash, in ints (i. e. the length of the bytes
+     * @param len   length of the subsequence to hash, in ints (i.e. the length of the bytes
      *              sequence to hash is {@code len * 4L})
      * @return hash code for the specified subsequence
      * @throws IndexOutOfBoundsException if {@code off < 0} or {@code off + len > input.length}
@@ -798,7 +798,7 @@ public abstract class LongHashFunction implements Serializable {
      *
      * @param input the array to read data from
      * @param off   index of the first {@code long} in the subsequence to hash
-     * @param len   length of the subsequence to hash, in longs (i. e. the length of the bytes
+     * @param len   length of the subsequence to hash, in longs (i.e. the length of the bytes
      *              sequence to hash is {@code len * 8L})
      * @return hash code for the specified subsequence
      * @throws IndexOutOfBoundsException if {@code off < 0} or {@code off + len > input.length}


### PR DESCRIPTION
## Summary
- Replaces `i. e.` with `i.e.` and `e. g.` with `e.g.` in javadoc / AsciiDoc / Markdown.
- Matches conventional English rendering and the style used elsewhere in these repos.
- Purely textual change, no code behaviour affected.

## Test plan
- [ ] Visual diff - only abbreviation spacing changes.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)