### PR TITLE
docs: restore the hashing Maven Central badge

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -3,7 +3,7 @@
 
 Chronicle Software
 
-image:https://maven-badges.herokuapp.com/maven-central/net.openhft/zero-allocation-hashing/badge.svg[caption="",link=https://maven-badges.herokuapp.com/maven-central/net.openhft/zero-allocation-hashing]
+image:https://img.shields.io/maven-central/v/net.openhft/zero-allocation-hashing.svg[caption="",link=https://central.sonatype.com/artifact/net.openhft/zero-allocation-hashing]
 image:https://javadoc.io/badge2/net.openhft/zero-allocation-hashing/javadoc.svg[link="https://www.javadoc.io/doc/net.openhft/zero-allocation-hashing/latest/index.html"]
 //image:https://javadoc-badge.appspot.com/net.openhft/zero-allocation-hashing.svg?label=javadoc[JavaDoc, link=https://www.javadoc.io/doc/net.openhft/zero-allocation-hashing]
 image:https://img.shields.io/github/license/OpenHFT/Zero-Allocation-Hashing[GitHub]


### PR DESCRIPTION
Replace the README version badge with [Shields' Maven Central API](https://shields.io/badges/maven-central-version) and link it to [net.openhft:zero-allocation-hashing](https://central.sonatype.com/artifact/net.openhft/zero-allocation-hashing). [The badge service's migration notice](https://github.com/softwaremill/maven-badges#readme) deprecated the Heroku URL and limited its availability to the end of 2025.

Validation on 9 September 2026: rendered the full README with Asciidoctor 2.0.20 without warnings; checked the rendered badge's destination and the POM coordinate. The badge SVG returned HTTP 200 with a version label, and the artifact page returned HTTP 200 for the intended artifact. `git diff --check` passes. The diff is one README line; Java tests were not rerun for this documentation edit.
