### PR TITLE
[#60] Publish a stable JPMS automatic module name

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -268,6 +268,7 @@
                         </Bundle-SymbolicName>
                         <Bundle-Name>OpenHFT :: ${project.artifactId}</Bundle-Name>
                         <Bundle-Version>${project.version}</Bundle-Version>
+                        <Automatic-Module-Name>net.openhft.hashing</Automatic-Module-Name>
                         <Export-Package>
                             net.openhft.hashing.*;-noimport:=true,
                             !java.*,
@@ -286,6 +287,24 @@
                         <goals>
                             <goal>manifest</goal>
                         </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>3.2.5</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                        <configuration>
+                            <systemPropertyVariables>
+                                <packaged.jar>${project.build.directory}/${project.build.finalName}.jar</packaged.jar>
+                            </systemPropertyVariables>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/src/test/java/net/openhft/hashing/AutomaticModuleNameIT.java
+++ b/src/test/java/net/openhft/hashing/AutomaticModuleNameIT.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ */
+package net.openhft.hashing;
+
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.jar.Attributes;
+import java.util.jar.JarFile;
+import java.util.jar.Manifest;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class AutomaticModuleNameIT {
+
+    private static final String EXPECTED_MODULE_NAME = "net.openhft.hashing";
+
+    @Test
+    public void packagedJarDeclaresAutomaticModuleName() throws IOException {
+        final String packagedJarPath = System.getProperty("packaged.jar");
+        assertNotNull("packaged.jar system property", packagedJarPath);
+
+        final File packagedJar = new File(packagedJarPath);
+        assertTrue("Packaged JAR does not exist: " + packagedJar, packagedJar.isFile());
+
+        try (JarFile jarFile = new JarFile(packagedJar)) {
+            final Manifest manifest = jarFile.getManifest();
+            assertNotNull("Packaged JAR has no manifest: " + packagedJar, manifest);
+            final Attributes attributes = manifest.getMainAttributes();
+            assertEquals(EXPECTED_MODULE_NAME, attributes.getValue("Automatic-Module-Name"));
+        }
+    }
+}


### PR DESCRIPTION
## What changed

- Publishes `Automatic-Module-Name: net.openhft.hashing` in the packaged bundle.
- Adds an integration test that opens the actual packaged JAR during Maven `verify`.

## Why

This is Stage 1 of issue #60. It establishes the permanent consumer-facing module name with minimal compatibility risk while retaining the Java 8 release build. The same name is used by the explicit descriptor proposed in #107, so consumers will not need to change their `requires net.openhft.hashing` declaration later.

This PR complements #107; it is not a replacement for that contribution.

## Scope and limitations

This stage provides:

- a stable automatic module name;
- use as an automatic module on Java 9+;
- a non-breaking path to an explicit descriptor.

It does not yet provide:

- a real `module-info.class`;
- strong encapsulation or an explicit `requires jdk.unsupported`;
- `jlink` support;
- complete module-path runtime hardening.

Those belong to the repository-owned continuation of #107 and the final hardening stage.

## Validation

- JDK 8: `mvn -B clean verify` — 14,901 unit tests, 12 skips; packaged-JAR integration test 1/1.
- The exact JDK 8-built JAR ran a public API smoke test on Java 8 and Java 25.
- Java 25 identified the JDK 8-built JAR as automatic module `net.openhft.hashing`.
- JDK 25: `mvn -o -B clean verify` — both configured unit-test executions and packaged-JAR integration test passed.
- TeamCity passed Java 8, 11, 17, 21, 25, 26, 27, Zing 8/11, and ARM on this source head.
- `git diff --check` passed.
- Reachable branch history contains no Claude or Anthropic references.

The legacy GitHub workflow currently fails before checkout because it uses retired `actions/cache@v1`. Its separate workflow/Sonar maintenance is intentionally outside this PR.

## Tracking

Part of #60.
Stage 1 of the JPMS migration.