### PR TITLE
Restore hash coverage and separate SonarCloud analysis

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,4 +67,22 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: mvn -B org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=OpenHFT_Zero-Allocation-Hashing -Psonar
+        run: |
+          python3 - <<'PY'
+          import base64
+          import json
+          import os
+          import urllib.request
+
+          token = os.environ.get("SONAR_TOKEN", "")
+          if not token:
+              raise SystemExit("SONAR_TOKEN is not configured")
+          credential = base64.b64encode((token + ":").encode()).decode()
+          request = urllib.request.Request(
+              "https://sonarcloud.io/api/authentication/validate",
+              headers={"Authorization": "Basic " + credential})
+          with urllib.request.urlopen(request, timeout=30) as response:
+              if not json.load(response).get("valid"):
+                  raise SystemExit("SonarCloud rejected SONAR_TOKEN; replace the configured credential")
+          PY
+          mvn -B org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=OpenHFT_Zero-Allocation-Hashing -Psonar

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,27 +11,60 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
-      - name: Set up JDK 11
-        uses: actions/setup-java@v1
+      - name: Set up JDK 21
+        uses: actions/setup-java@v6
         with:
-          java-version: 11
-      - name: Cache SonarCloud packages
-        uses: actions/cache@v1
-        with:
-          path: ~/.sonar/cache
-          key: ${{ runner.os }}-sonar
-          restore-keys: ${{ runner.os }}-sonar
+          distribution: zulu
+          java-version: '21'
       - name: Cache Maven packages
-        uses: actions/cache@v1
+        uses: actions/cache@v6
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
-      - name: Build and analyze
+      - name: Maven verification and coverage
+        run: |
+          mvn -B verify -Psonar
+          test -s target/site/jacoco/jacoco.xml
+      - name: Retain classes and coverage for analysis
+        uses: actions/upload-artifact@v7
+        with:
+          name: sonar-inputs
+          path: |
+            target/classes
+            target/test-classes
+            target/site/jacoco/jacoco.xml
+          if-no-files-found: error
+  sonar:
+    name: SonarCloud analysis
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - name: Set up JDK 21
+        uses: actions/setup-java@v6
+        with:
+          distribution: zulu
+          java-version: '21'
+          cache: maven
+      - name: Restore classes and coverage
+        uses: actions/download-artifact@v8
+        with:
+          name: sonar-inputs
+          path: target
+      - name: Cache SonarCloud packages
+        uses: actions/cache@v6
+        with:
+          path: ~/.sonar/cache
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
+      - name: Analyse
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: mvn -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=OpenHFT_Zero-Allocation-Hashing -Psonar
+        run: mvn -B org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=OpenHFT_Zero-Allocation-Hashing -Psonar

--- a/pom.xml
+++ b/pom.xml
@@ -203,6 +203,7 @@
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
+                    <argLine>@{surefireArgLine} @{argLine} ${jvm.requiredArgs}</argLine>
                     <enableAssertions>true</enableAssertions>
                     <reuseForks>false</reuseForks>
                 </configuration>
@@ -359,7 +360,7 @@
                                     <goal>test</goal>
                                 </goals>
                                 <configuration>
-                                    <argLine>@{argLine} -XX:-CompactStrings ${jvm.requiredArgs}</argLine>
+                                    <argLine>@{surefireArgLine} @{argLine} -XX:-CompactStrings ${jvm.requiredArgs}</argLine>
                                 </configuration>
                             </execution>
                         </executions>
@@ -392,7 +393,7 @@
                                     <goal>test</goal>
                                 </goals>
                                 <configuration>
-                                    <argLine>@{argLine} -XX:-CompactStrings ${jvm.requiredArgs}</argLine>
+                                    <argLine>@{surefireArgLine} @{argLine} -XX:-CompactStrings ${jvm.requiredArgs}</argLine>
                                 </configuration>
                             </execution>
                         </executions>

--- a/src/main/docs/testing-strategy.adoc
+++ b/src/main/docs/testing-strategy.adoc
@@ -35,4 +35,6 @@ The source programs used to generate those vectors are embedded in each test for
 === Build and Verification
 
 * Run `mvn -q verify` from the repository root before publishing changes; the goal invokes unit tests under the appropriate JVM profiles and ensures multi-version compatibility.
+* GitHub Actions reports Maven verification and SonarCloud analysis as separate jobs on JDK 21. The Maven compiler still targets Java 8. Analysis consumes the compiled classes and JaCoCo XML produced by verification.
+* `mvn -Psonar verify` collects coverage from both string-layout executions through the JaCoCo-prepared `surefireArgLine` property. The SonarCloud job requires a `SONAR_TOKEN` with analysis permission for project `OpenHFT_Zero-Allocation-Hashing` in organisation `openhft`.
 * Include new regression cases alongside the code change so future automated runs catch behavioural drift without manual intervention.


### PR DESCRIPTION
Maven's `sonar` profile prepares `surefireArgLine`, but the default test execution expands it before JaCoCo runs and the non-compact-string executions use a different property. Both JVM paths therefore run without the agent and silently skip coverage reporting/checking.

Use late evaluation of `surefireArgLine` for every unit-test execution. Keep Maven verification in the existing `Build` check, require its JaCoCo XML to exist, and give SonarCloud analysis its own dependent job consuming the verified classes and coverage artifact. Move the Actions/JDK updates and testing-strategy note out of seed-contract PR #120. No failure is suppressed.

Validation on Linux x86-64, OpenJDK 21, Maven 3.9.11, isolated cached dependencies:

- Before: focused `mvn -Psonar -Dtest=MurmurHash3Test -X clean verify` passes, but both fork commands lack `-javaagent` and `target/jacoco.exec` is absent.
- After: full `mvn -Psonar -X clean verify` passes two 14,901-case unit executions (5 and 8 skips), plus the automatic-module-name integration test. All 38 unit-test forks receive the JaCoCo agent, including all 19 non-compact-string forks.
- JaCoCo reports 1,797/1,976 lines (90.9%) and 262/311 branches (84.2%); existing coverage thresholds pass. Effective POM and actual fork commands were inspected.
- `git diff --check` passes.
- Fresh [Actions run 34696556693](https://github.com/OpenHFT/Zero-Allocation-Hashing/actions/runs/34696556693) executes this head's workflow: the separate Build job passes, classes/coverage upload and download succeed, and only the SonarCloud analysis job fails with the same authentication/project-access error.

The remaining Sonar blocker is now classified as rejection of the configured credential. [Run 34697089926](https://github.com/OpenHFT/Zero-Allocation-Hashing/actions/runs/34697089926) at `88a87c46f293e4dba01cc9bc882207ca9956e060` again passes Build and the artifact transfer; the added authentication check receives `valid: false` from SonarCloud for `SONAR_TOKEN` and fails explicitly before scanning. The check sends the credential only to SonarCloud and does not print its value. [Job 103523545730](https://github.com/OpenHFT/Zero-Allocation-Hashing/actions/runs/34682484035/job/103523545730) supplies a masked `SONAR_TOKEN` and fails with `Not authorized or project not found` after successful tests. The public [SonarCloud project API](https://sonarcloud.io/api/components/show?component=OpenHFT_Zero-Allocation-Hashing) confirms project `OpenHFT_Zero-Allocation-Hashing` belongs to organisation `openhft`. The available GitHub credential cannot inspect organisation secret metadata (HTTP 403). An administrator must replace or repair the configured credential, confirm its analysis permission for this project, and rerun analysis. Token expiry is not established by this result. Keep this repair draft until analysis succeeds.

The property wiring follows [JaCoCo's prepare-agent guidance](https://www.jacoco.org/jacoco/trunk/doc/prepare-agent-mojo.html).